### PR TITLE
HELM_UNINSTALL_CHART option (#34)

### DIFF
--- a/docs/tool-configuration/configuration-helm.md
+++ b/docs/tool-configuration/configuration-helm.md
@@ -16,6 +16,7 @@ helm:
   options:
     skip-deploy: false
     release-name: bitops-release
+    uninstall-charts: "chart1,chart2"
     kubeconfig:
       path: ./path/to/kubeconfig
       fetch:
@@ -101,6 +102,14 @@ will skip helm execution
 * **default:** `""`
 
 sets helm release name
+
+-------------------
+### uninstall-charts
+* **BitOps Property:** `uninstall-charts`
+* **Environment Variable:** `HELM_UNINSTALL_CHARTS`
+* **default:** `""`
+
+Comma separated string. If any of the charts to be deployed match one of the chart names listed here, it will be uninstalled with `helm uninstall $HELM_RELEASE_NAME` instead of deployed/upgraded.
 
 -------------------
 ### kubeconfig

--- a/scripts/bitops-config/get-convert.sh
+++ b/scripts/bitops-config/get-convert.sh
@@ -36,8 +36,8 @@ v="$(bash "$SCRIPTS_DIR/bitops-config/get.sh" "$config_file" "$key" "$default")"
 OUTPUT="$(bash "$SCRIPTS_DIR/bitops-config/convert.sh" "$v" "$key_type" "$cli_flag" "$terminal")"
 
 if [ -n "$export_env" ] && [ -n "$ENV_FILE" ] && [ -n "$v" ]; then
-  # echo "export ${export_env}='$v'" >> $ENV_FILE
-  echo "${export_env}='$v'" >> $ENV_FILE
+  echo "export ${export_env}='$v'" >> $ENV_FILE
+  # echo "${export_env}='$v'" >> $ENV_FILE
 fi
 
 if [ -n "$required" ] && [ -z "$v" ]; then

--- a/scripts/helm/bitops.schema.yaml
+++ b/scripts/helm/bitops.schema.yaml
@@ -42,6 +42,9 @@ helm:
         release-name:
           type: string
           export_env: HELM_RELEASE_NAME
+        uninstall-charts:
+          type: string
+          export_env: HELM_UNINSTALL_CHARTS
         kubeconfig:
           type: object
           properties:
@@ -58,6 +61,7 @@ helm:
                 cluster-name:
                   type: string
                   export_env: CLUSTER_NAME
+        
     plugins:
       type: object
       properties:

--- a/scripts/helm/deploy.sh
+++ b/scripts/helm/deploy.sh
@@ -12,13 +12,13 @@ export DEFAULT_HELM_ROOT="$DEFAULT_ENVROOT/helm"
 if [ -z "$ENVIRONMENT_HELM_SUBDIRECTORY" ]; then
   echo "ENVIRONMENT_HELM_SUBDIRECTORY not provided, iterate all helm charts in $ENV_DIR/helm"
   for helm_chart_dir in $HELM_ROOT/*/; do
-    helm_chart_dir=${helm_chart_dir%*/}      # remove the trailing "/"
+    helm_chart_dir=${helm_chart_dir%*/}     # remove the trailing "/"
     helm_chart_dir=${helm_chart_dir##*/}    # get everything after the final "/"
     echo "Deploy $helm_chart_dir for $ENVIRONMENT"
-    $SCRIPTS_DIR/helm/deploy-chart.sh $helm_chart_dir
+    $SCRIPTS_DIR/helm/helm_handle_chart.sh $helm_chart_dir
   done
 else
   echo "ENVIRONMENT_HELM_SUBDIRECTORY: $ENV_DIR/helm/$ENVIRONMENT_HELM_SUBDIRECTORY"
-  $SCRIPTS_DIR/helm/deploy-chart.sh $ENVIRONMENT_HELM_SUBDIRECTORY
+  $SCRIPTS_DIR/helm/helm_handle_chart.sh $ENVIRONMENT_HELM_SUBDIRECTORY
 fi
 

--- a/scripts/helm/helm_deploy_chart.sh
+++ b/scripts/helm/helm_deploy_chart.sh
@@ -1,70 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-HELM_CHART="$1"
-HELM_CHART_DIRECTORY="$HELM_ROOT/$HELM_CHART"
-DEFAULT_HELM_CHART_DIRECTORY="$DEFAULT_HELM_ROOT/$HELM_CHART"
-HELM_BITOPS_CONFIG="$HELM_CHART_DIRECTORY/bitops.config.yaml" 
-BITOPS_CONFIG_SCHEMA="$SCRIPTS_DIR/helm/bitops.schema.yaml"
-BITOPS_SCHEMA_ENV_FILE="$HELM_CHART_DIRECTORY/ENV_FILE"
-IMG_REPO=""
-
-echo "Installing charts..."
-
-output_schema_env () {
-    echo "Schema ENV"
-    cat "$BITOPS_SCHEMA_ENV_FILE"
-}
-on_exit () {
-    output_schema_env
-}
-trap "{ on_exit; }" EXIT
-
-# Check for Before Deploy Scripts
-bash $SCRIPTS_DIR/deploy/before-deploy.sh "$HELM_CHART_DIRECTORY"
-
-BITOPS_CONFIG_COMMAND="$(ENV_FILE="$BITOPS_SCHEMA_ENV_FILE" DEBUG="" bash $SCRIPTS_DIR/bitops-config/convert-schema.sh $BITOPS_CONFIG_SCHEMA $HELM_BITOPS_CONFIG)"
-echo "BITOPS_CONFIG_COMMAND: $BITOPS_CONFIG_COMMAND"
-source "$BITOPS_SCHEMA_ENV_FILE"
-
-# set kube config
-if [[ "${KUBE_CONFIG_PATH}" == "" ]] || [[ "${KUBE_CONFIG_PATH}" == "''" ]] || [[ "${KUBE_CONFIG_PATH}" == "None" ]]; then
-    if [[ "${FETCH_KUBECONFIG}" == "True" ]]; then
-        if [[ "${CLUSTER_NAME}" == "" ]] || [[ "${CLUSTER_NAME}" == "''" ]] || [[ "${CLUSTER_NAME}" == "None" ]]; then
-            >&2 echo "{\"error\":\"CLUSTER_NAME config is required.Exiting...\"}"
-            exit 1
-        else
-            # always get the kubeconfig (whether or not we applied)
-            echo "Attempting to fetch KUBECONFIG from cloud provider..."
-            CLUSTER_NAME="$CLUSTER_NAME" \
-            KUBECONFIG="$KUBE_CONFIG_FILE" \
-            bash $SCRIPTS_DIR/aws/eks.update-kubeconfig.sh
-            export KUBECONFIG=$KUBECONFIG:$KUBE_CONFIG_FILE
-        fi   
-    else
-        if [[ "${FETCH_KUBECONFIG}" == "False" ]]; then
-            >&2 echo "{\"error\":\"one or more 'kubeconfig' variables are undefined in bitops.config.yaml.Exiting...\"}"
-            exit 1
-        fi
-    fi
-else
-    if [[ -f "$KUBE_CONFIG_PATH" ]]; then
-        echo "$KUBE_CONFIG_PATH exists."
-        KUBE_CONFIG_FILE="$KUBE_CONFIG_PATH" \
-        KUBECONFIG="$KUBE_CONFIG_FILE" \
-        export KUBECONFIG=$KUBECONFIG:$KUBE_CONFIG_FILE
-    else
-        >&2 echo "{\"error\":\"kubeconfig path variable wrong in bitops.config.yaml.Exiting...\"}"
-        exit 1
-    fi
-fi
-
-echo "call validate_env with NAMESPACE: $NAMESPACE"
-NAMESPACE="$NAMESPACE" \
-bash $SCRIPTS_DIR/helm/validate_env.sh
-
 # Initialize values files
-
 VALUES_FILE_PATH="$HELM_CHART_DIRECTORY/values.yaml"
 DEFAULT_VALUES_FILE_PATH="$DEFAULT_HELM_CHART_DIRECTORY/values.yaml"
 VALUES_SECRETS_FILE_PATH="$HELM_CHART_DIRECTORY/values-secrets.yaml"
@@ -83,16 +20,6 @@ else
   echo "${HELM_SECRETS_BASE64}" | base64 -d > "$VALUES_SECRETS_FILE_PATH"
   echo "helm values-secrets created from HELM_SECRETS_BASE64: $VALUES_SECRETS_FILE_PATH"
 fi
-
-
-### COPY DEFAULTS
-HELM_CHART_DIRECTORY="$HELM_CHART_DIRECTORY" \
-DEFAULT_HELM_CHART_DIRECTORY="$DEFAULT_HELM_CHART_DIRECTORY" \
-HELM_BITOPS_CONFIG="$HELM_BITOPS_CONFIG" \
-bash -x $SCRIPTS_DIR/helm/copy-defaults.sh "$HELM_CHART"
-
-
-# TODO: fix below here
 
 VALUES_FILES_ORDER="
 $DEFAULT_VALUES_FILE_PATH
@@ -139,19 +66,6 @@ else
     echo "No values file directory. Skipping..."
 fi
 
-
-# Deploy Chart.
-echo "Updating dependencies in '$HELM_CHART_DIRECTORY' ..."
-helm dep up "$HELM_CHART_DIRECTORY"
-
-
-if [ -n "HELM_RELEASE_NAME" ]; then
-    HELM_RELEASE_NAME="$HELM_CHART"
-fi
-k="kubectl --kubeconfig=$KUBE_CONFIG_FILE"
-h="helm --kubeconfig=$KUBE_CONFIG_FILE"
-
-
 # Check if namespace exists and create it if it doesn't.
 k="$k" \
 NAMESPACE="$NAMESPACE" \
@@ -159,10 +73,7 @@ HELM_CHART="$HELM_CHART" \
 HELM_CHART_DIRECTORY="$HELM_CHART_DIRECTORY" \
 bash -x $SCRIPTS_DIR/helm/ensure-namespace-exists.sh
 
-
 # TODO: helm lint
-
-
 RESULT=""
 $h list --all --all-namespaces > /tmp/check_release.txt
 
@@ -204,7 +115,6 @@ else
             HELM_DEBUG_COMMAND="--debug"
         fi
 
-
         echo "The previous instalation failed. Rolling back to last successful release."
         $h rollback \
         $HELM_RELEASE_NAME 0 \
@@ -213,25 +123,3 @@ else
         $HELM_DEBUG_COMMAND
     fi
 fi
-
-# Run After Deploy Scripts if any.
-
-bash $SCRIPTS_DIR/deploy/after-deploy.sh $HELM_CHART_DIRECTORY
-
-printf "${SUCCESS} Helm deployment was successful...${NC}"
-
-
-# TODO: do we need this?
-# if [ -z "$EXTERNAL_HELM_CHARTS" ]; then 
-#     echo "EXTERNAL_HELM_CHARTS directory not set."
-# else
-#     echo "Running External Helm Charts."
-#     bash -x $SCRIPTS_DIR/helm/helm_install_external_charts.sh
-# fi
-
-# if [ -z "$HELM_CHARTS_S3" ]; then
-#     echo "HELM_CHARTS_S3 not set."
-# else
-#     echo "Adding S3 Helm Repo."
-#     bash -x $SCRIPTS_DIR/helm/helm_install_charts_from_s3.sh 
-# fi

--- a/scripts/helm/helm_handle_chart.sh
+++ b/scripts/helm/helm_handle_chart.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -e
+
+export HELM_CHART="$1"
+export HELM_CHART_DIRECTORY="$HELM_ROOT/$HELM_CHART"
+export DEFAULT_HELM_CHART_DIRECTORY="$DEFAULT_HELM_ROOT/$HELM_CHART"
+export HELM_BITOPS_CONFIG="$HELM_CHART_DIRECTORY/bitops.config.yaml" 
+export BITOPS_CONFIG_SCHEMA="$SCRIPTS_DIR/helm/bitops.schema.yaml"
+export BITOPS_SCHEMA_ENV_FILE="$HELM_CHART_DIRECTORY/ENV_FILE"
+
+echo "Installing charts..."
+
+output_schema_env () {
+    echo "Schema ENV"
+    cat "$BITOPS_SCHEMA_ENV_FILE"
+}
+on_exit () {
+    output_schema_env
+}
+trap "{ on_exit; }" EXIT
+
+# Check for Before Deploy Scripts
+bash $SCRIPTS_DIR/deploy/before-deploy.sh "$HELM_CHART_DIRECTORY"
+
+# Load bitops.config.yaml
+export BITOPS_CONFIG_COMMAND="$(ENV_FILE="$BITOPS_SCHEMA_ENV_FILE" DEBUG="" bash $SCRIPTS_DIR/bitops-config/convert-schema.sh $BITOPS_CONFIG_SCHEMA $HELM_BITOPS_CONFIG)"
+echo "BITOPS_CONFIG_COMMAND: $BITOPS_CONFIG_COMMAND"
+source "$BITOPS_SCHEMA_ENV_FILE"
+
+# set kube config
+if [[ "${KUBE_CONFIG_PATH}" == "" ]] || [[ "${KUBE_CONFIG_PATH}" == "''" ]] || [[ "${KUBE_CONFIG_PATH}" == "None" ]]; then
+    if [[ "${FETCH_KUBECONFIG}" == "True" ]]; then
+        if [[ "${CLUSTER_NAME}" == "" ]] || [[ "${CLUSTER_NAME}" == "''" ]] || [[ "${CLUSTER_NAME}" == "None" ]]; then
+            >&2 echo "{\"error\":\"CLUSTER_NAME config is required.Exiting...\"}"
+            exit 1
+        else
+            # always get the kubeconfig (whether or not we applied)
+            echo "Attempting to fetch KUBECONFIG from cloud provider..."
+            CLUSTER_NAME="$CLUSTER_NAME" \
+            KUBECONFIG="$KUBE_CONFIG_FILE" \
+            bash $SCRIPTS_DIR/aws/eks.update-kubeconfig.sh
+            export KUBECONFIG=$KUBECONFIG:$KUBE_CONFIG_FILE
+        fi   
+    else
+        if [[ "${FETCH_KUBECONFIG}" == "False" ]]; then
+            >&2 echo "{\"error\":\"one or more 'kubeconfig' variables are undefined in bitops.config.yaml.Exiting...\"}"
+            exit 1
+        fi
+    fi
+else
+    if [[ -f "$KUBE_CONFIG_PATH" ]]; then
+        echo "$KUBE_CONFIG_PATH exists."
+        KUBE_CONFIG_FILE="$KUBE_CONFIG_PATH" \
+        KUBECONFIG="$KUBE_CONFIG_FILE" \
+        export KUBECONFIG=$KUBECONFIG:$KUBE_CONFIG_FILE
+    else
+        >&2 echo "{\"error\":\"kubeconfig path variable wrong in bitops.config.yaml.Exiting...\"}"
+        exit 1
+    fi
+fi
+export k="kubectl --kubeconfig=$KUBE_CONFIG_FILE"
+export h="helm --kubeconfig=$KUBE_CONFIG_FILE"
+
+echo "call validate_env with NAMESPACE: $NAMESPACE"
+if [ -n "$HELM_RELEASE_NAME" ]; then
+    HELM_RELEASE_NAME="$HELM_CHART"
+fi
+bash $SCRIPTS_DIR/helm/validate_env.sh
+
+### COPY DEFAULTS
+HELM_CHART_DIRECTORY="$HELM_CHART_DIRECTORY" \
+DEFAULT_HELM_CHART_DIRECTORY="$DEFAULT_HELM_CHART_DIRECTORY" \
+HELM_BITOPS_CONFIG="$HELM_BITOPS_CONFIG" \
+bash -x $SCRIPTS_DIR/helm/copy-defaults.sh "$HELM_CHART"
+
+# TODO Check for HELM_UNINSTALL env flag
+
+# Deploy Chart.
+echo "Updating dependencies in '$HELM_CHART_DIRECTORY' ..."
+helm dep up "$HELM_CHART_DIRECTORY"
+bash $SCRIPTS_DIR/helm/helm_deploy_chart.sh
+
+# TODO Uninstall Chart
+
+
+# Run After Deploy Scripts if any.
+bash $SCRIPTS_DIR/deploy/after-deploy.sh $HELM_CHART_DIRECTORY
+
+printf "${SUCCESS} Helm deployment was successful...${NC}"
+
+
+# TODO: do we need this?
+# if [ -z "$EXTERNAL_HELM_CHARTS" ]; then 
+#     echo "EXTERNAL_HELM_CHARTS directory not set."
+# else
+#     echo "Running External Helm Charts."
+#     bash -x $SCRIPTS_DIR/helm/helm_install_external_charts.sh
+# fi
+
+# if [ -z "$HELM_CHARTS_S3" ]; then
+#     echo "HELM_CHARTS_S3 not set."
+# else
+#     echo "Adding S3 Helm Repo."
+#     bash -x $SCRIPTS_DIR/helm/helm_install_charts_from_s3.sh 
+# fi

--- a/scripts/helm/helm_uninstall_chart.sh
+++ b/scripts/helm/helm_uninstall_chart.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Running helm uninstall..."
+$h list --all --namespace $NAMESPACE > /tmp/check_release.txt
+if [ -n "$(grep "$HELM_RELEASE_NAME" /tmp/check_release.txt)" ]; then 
+  $h uninstall $HELM_RELEASE_NAME --namespace $NAMESPACE
+else
+  printf "${WARN}${HELM_RELEASE_NAME} does not exist in namespace ${NAMESPACE} ${NC}\n"
+fi


### PR DESCRIPTION
This change adds the ability to uninstall helm charts with BitOps (#34), in addition to a re-structuring of `scripts/helm/`

Prior to this change
* `scripts/helm/deploy.sh`: loops through all charts in the `<env>/helm/` and calls `scripts/helm/deploy-chart.sh` for each
* `scripts/helm/deploy-chart.sh`: runs lifecycle hooks, configures cluster access and installs/upgrades the chart

This makes it awkward to include `helm_unsintall.sh`. `deploy-chart.sh` is a large file with multiple responsibilities. It needs to be broken up.

New flow
* `scripts/helm/deploy.sh`: loops through all charts in the `<env>/helm/` and calls `scripts/helm/helm_handle_chart.sh` for each
* `scripts/helm/helm_handle_chart.sh`: runs lifecycle hooks, configures cluster access and calls either `scripts/helm/helm_deploy_chart.sh` or `scripts/helm/helm_uninstall_chart.sh` based on config
