### PR TITLE
Added handling for Ansible extra-vars options

### DIFF
--- a/docs/tool-configuration/configuration-ansible.md
+++ b/docs/tool-configuration/configuration-ansible.md
@@ -10,6 +10,7 @@ ansible:
     forks: 20
     inventory: beta
     tags: run-this-tag
+    extra-vars: "@extra-vars.json"
   options:
     dryrun: false
 ```

--- a/docs/tool-configuration/configuration-ansible.md
+++ b/docs/tool-configuration/configuration-ansible.md
@@ -58,6 +58,13 @@ specify inventory host path or comma separated host list.
 
 only run plays and tasks tagged with these values
 
+-------------------
+### extra-vars
+* **BitOps Property:** `extra-vars`
+* **Environment Variable:** `BITOPS_ANSIBLE_EXTRA_VARS`
+
+add additional ansible playbook parameters directly or load via JSON/YAML file
+
 ## Options Configuration
 
 -------------------

--- a/scripts/ansible/bitops.schema.yaml
+++ b/scripts/ansible/bitops.schema.yaml
@@ -28,6 +28,10 @@ ansible:
           type: string
           parameter: tags
           export_env: BITOPS_ANSIBLE_TAGS
+        extra-vars:
+          type: string
+          parameter: extra-vars
+          export_env: BITOPS_ANSIBLE_EXTRA_VARS
     options:
       type: object
       properties:


### PR DESCRIPTION
I've done some testing using this with the ST2 Ansible deployment+a modified BitOps image and it seems to operate correctly.

I can pass in vars directly or load from a json file as described in the docs, both work:
https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#defining-variables-at-runtime