### PR TITLE
added rsync and openssh packages for Ansible synchronize support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@ RUN apk add \
     unzip \
     git \
     jq \
-    curl
+    curl \
+    rsync \
+    openssh
     
 # install glibc compatibility for alpine
 ENV GLIBC_VER=2.31-r0


### PR DESCRIPTION
Ansible has a 'synchronize' command which is equivalent to using rsync, whereas the normal ansible `copy` command relates to `cp`.

Using synchronize vs copy can save time on the order of minutes, using recent client data as an example:
_(time is for full bitops docker container execution, transfer data has first been synced to the BitOps container)_

Transfer size: ~37MB

Copy:
Best: 4m35s
Worst: 9m49s

Synchronize:
Best: 1m30s
Worst: 1m34s

Adding rsync and openssh packages only adds ~1MB to image size