### PR TITLE
Adding init-upgrade option to terraform

### DIFF
--- a/docs/example-config-files/terraform.bitops.config.yaml
+++ b/docs/example-config-files/terraform.bitops.config.yaml
@@ -2,10 +2,9 @@ terraform:
     cli: 
       backend-config:
         - KEY1=foo
-          KEY2=bar
-        - KEY3=baz
-      init-upgrade: true
+        - KEY2=bar
     options:
         command: apply
         version: "0.13.2"
         fetch-kubeconfig: false
+        init-upgrade: true

--- a/docs/example-config-files/terraform.bitops.config.yaml
+++ b/docs/example-config-files/terraform.bitops.config.yaml
@@ -1,8 +1,9 @@
 terraform:
     cli: 
       backend-config:
-        KEY1=foo
-        KEY2=bar
+        - KEY1=foo
+          KEY2=bar
+        - KEY3=baz
       init-upgrade: true
     options:
         command: apply

--- a/docs/example-config-files/terraform.bitops.config.yaml
+++ b/docs/example-config-files/terraform.bitops.config.yaml
@@ -1,9 +1,9 @@
 terraform:
     cli: 
       backend-config:
-        - KEY1=foo
-        - KEY2=bar
-      init-upgrade: false
+        KEY1=foo
+        KEY2=bar
+      init-upgrade: true
     options:
         command: apply
         version: "0.13.2"

--- a/docs/example-config-files/terraform.bitops.config.yaml
+++ b/docs/example-config-files/terraform.bitops.config.yaml
@@ -3,6 +3,7 @@ terraform:
       backend-config:
         - KEY1=foo
         - KEY2=bar
+      init-upgrade: false
     options:
         command: apply
         version: "0.13.2"

--- a/docs/tool-configuration/configuration-terraform.md
+++ b/docs/tool-configuration/configuration-terraform.md
@@ -85,3 +85,5 @@ Will force call `terraform apply`
 Will force call `terraform destroy`
 
 -------------------
+### INIT_UPGRADE
+Will add `--upgrade` flag to the init command

--- a/scripts/terraform/bitops.schema.yaml
+++ b/scripts/terraform/bitops.schema.yaml
@@ -19,7 +19,6 @@ terraform:
         init-upgrade:
           type: boolean
           parameter: upgrade
-          dash_type: '--'
           default: false
           
     options:

--- a/scripts/terraform/bitops.schema.yaml
+++ b/scripts/terraform/bitops.schema.yaml
@@ -16,6 +16,11 @@ terraform:
           type: parameter-list
           parameter: backend-config
           dash_type: "-"
+        init-upgrade:
+          type: boolean
+          parameter: upgrade
+          dash_type: '--'
+          default: false
           
     options:
       type: object

--- a/scripts/terraform/bitops.schema.yaml
+++ b/scripts/terraform/bitops.schema.yaml
@@ -16,10 +16,6 @@ terraform:
           type: parameter-list
           parameter: backend-config
           dash_type: "-"
-        init-upgrade:
-          type: boolean
-          parameter: upgrade
-          default: false
           
     options:
       type: object
@@ -35,3 +31,7 @@ terraform:
         workspace:
           type: string
           export_env: TERRAFORM_WORKSPACE
+        init-upgrade:
+          type: boolean
+          export_env: INIT_UPGRADE
+          default: false

--- a/scripts/terraform/deploy.sh
+++ b/scripts/terraform/deploy.sh
@@ -44,7 +44,7 @@ ln -s /usr/local/bin/terraform-$TERRAFORM_VERSION /usr/local/bin/terraform
 # always init first
 echo "Running terraform init"
 upgrade=""
-if [[ "$INIT_UPGRADE" == "True" ]];then
+if [ "${INIT_UPGRADE}" == "True" ] || [ "${INIT_UPGRADE}" == "true" ]; then
   upgrade="--upgrade"
 else
   echo "init upgrade not found in config. Skipping upgrade.."

--- a/scripts/terraform/deploy.sh
+++ b/scripts/terraform/deploy.sh
@@ -50,9 +50,6 @@ else
   echo "init upgrade not found in config. Skipping upgrade.."
 fi
 
-echo "terraform init -input=false $upgrade"
-exit 42
-
 if [ -n "$TERRAFORM_WORKSPACE" ]; then
   echo "Running Terraform Workspace"
   bash $SCRIPTS_DIR/terraform/terraform_workspace.sh $TERRAFORM_WORKSPACE

--- a/scripts/terraform/deploy.sh
+++ b/scripts/terraform/deploy.sh
@@ -43,8 +43,14 @@ ln -s /usr/local/bin/terraform-$TERRAFORM_VERSION /usr/local/bin/terraform
 
 # always init first
 echo "Running terraform init"
-terraform init -input=false
+upgrade=""
+if [[ "$BITOPS_CONFIG_COMMAND" == *"--upgrade"* ]];then
+  upgrade="--upgrade"
+else
+  echo "init upgrade not found in config. Skipping upgrade.."
+fi
 
+echo "terraform init -input=false $upgrade"
 
 if [ -n "$TERRAFORM_WORKSPACE" ]; then
   echo "Running Terraform Workspace"

--- a/scripts/terraform/deploy.sh
+++ b/scripts/terraform/deploy.sh
@@ -44,13 +44,14 @@ ln -s /usr/local/bin/terraform-$TERRAFORM_VERSION /usr/local/bin/terraform
 # always init first
 echo "Running terraform init"
 upgrade=""
-if [[ "$BITOPS_CONFIG_COMMAND" == *"--upgrade"* ]];then
+if [[ "$INIT_UPGRADE" == "True" ]];then
   upgrade="--upgrade"
 else
   echo "init upgrade not found in config. Skipping upgrade.."
 fi
 
 echo "terraform init -input=false $upgrade"
+exit 42
 
 if [ -n "$TERRAFORM_WORKSPACE" ]; then
   echo "Running Terraform Workspace"


### PR DESCRIPTION
init-upgrade option added to bitops schema + config example

Results of convert-schema.sh without `init-upgrade` flag
`script_options: [  -backend-config="KEY1=foo" -backend-config="KEY2=bar"]`

Results of convert-schema.sh with `init-upgrade` flag
`script_options: [  -backend-config="KEY1=foo" -backend-config="KEY2=bar" --upgrade]`