### PR TITLE
Fix navigation links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,9 +38,9 @@ nav:
   - Lifecycle: lifecycle.md
   - Examples: examples.md
   - Contributing:
-    - Contributing Guide: contributing/contributing.md
-    - Development Guide: contributing/development.md
-    - DCO: contributing/DCO.md
+    - Contributing Guide: contributing.md
+    - Development Guide: development/development.md
+    - DCO: development/DCO.md
     - Open Issues: https://github.com/bitovi/bitops/issues" target="_blank
     - License: license.md
 


### PR DESCRIPTION
# Description

Fixes the following documentation issues:
- The navigation link currently includes the `.md` file extension.
- The contributing page is not located in a directory, but the link includes a directory.
- The `DCO.md` file is in the development directory, and again the contributing directory does not exist.
- The left navigation in both the contributing and development pages do not render.

## Type of change

Please delete options that are not relevant.
- [x] Documentation update

# How Has This Been Tested?

N/A, documentation change

# Checklist:

- [x] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
