### PR TITLE
Add GitHub star button to the docs page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ hide:
             <a href="https://github.com/bitovi/bitops/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/bitovi/bitops"></a>
             <a href="https://www.bitovi.com/community/slack?utm_source=badge&amp;utm_medium=badge&amp;utm_campaign=pr-badge&amp;utm_content=badge"><img alt="Join our Slack" src="https://img.shields.io/badge/slack-join%20chat-611f69.svg"></a>
             <a href="license/"><img alt="LICENSE" src="https://img.shields.io/badge/license-MIT-green"></a>
+            <a class="github-button" href="https://github.com/bitovi/bitops" data-icon="octicon-star" data-show-count="true" aria-label="Star BitOps on GitHub">Star</a>
         </p>
     </div>
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,8 @@ hide:
  - navigation
 ---
 
+<script async defer src="https://buttons.github.io/buttons.js"></script>
+
 <!-- Custom hero banner using docs/stylesheets/custom.css -->
 <div class="bitovi-row">
     <div class="bitovi-column">


### PR DESCRIPTION
Adds  ![image](https://user-images.githubusercontent.com/1533818/180297723-7cc2fd7d-a443-4e56-b6aa-53bc9aba2e3a.png) to the list of buttons here https://bitovi.github.io/bitops/

Now looking how to place the `.js` code properly in the `<head>` per https://buttons.github.io.