### PR TITLE
Fix bitops.cofig.yml -> bitops.config.yaml references in docs

### DIFF
--- a/docs/cloud-configuration/configuration-aws.md
+++ b/docs/cloud-configuration/configuration-aws.md
@@ -1,6 +1,6 @@
 # AWS
 
-`bitops.config.yml` is not yet supported for AWS ([TODO](https://github.com/bitovi/bitops/issues/15)). All configuration must be done with environment variables
+`bitops.config.yaml` is not yet supported for AWS ([TODO](https://github.com/bitovi/bitops/issues/15)). All configuration must be done with environment variables
 
 ## Configuration
 

--- a/docs/configuration-base.md
+++ b/docs/configuration-base.md
@@ -1,11 +1,11 @@
 # Base Configuration
 
 Each deployment tool is traditionally controlled with a set of cli arguments. Instead of defining arguments within your pipeline configuration, they
- can instead either be defined with environment variables or in a `bitops.config.yml` file. While the core schema for a `bitops.config.yml` file is common betwen tools, the specific properties and environment variable equivilants vary from tool to tool.
+ can instead either be defined with environment variables or in a `bitops.config.yaml` file. While the core schema for a `bitops.config.yaml` file is common betwen tools, the specific properties and environment variable equivilants vary from tool to tool.
 
 -------------------
 ## Base Schema
-All `bitops.config.yml` files share the following structure
+All `bitops.config.yaml` files share the following structure
 ```
 $tool
   cli: {}

--- a/docs/default-environment.md
+++ b/docs/default-environment.md
@@ -10,11 +10,11 @@ Suppose we are working with an operations repo that is exlusviely terraform. We 
 │       └── main.tf
 ├── production
 │   └── terraform
-│       └── bitops.config.yml
+│       └── bitops.config.yaml
 │       └── production.auto.tfvars
 └── test
     └── terraform
-        └── bitops.config.yml
+        └── bitops.config.yaml
         └── test.auto.tfvars
 ```
 When `$ENVIRONMENT` is set to `production`, `default/` will be merged in to `production/` at runtime to produce a directory structure that looks like
@@ -24,12 +24,12 @@ When `$ENVIRONMENT` is set to `production`, `default/` will be merged in to `pro
 │       └── main.tf
 ├── production
 │   └── terraform
-│       └── bitops.config.yml
+│       └── bitops.config.yaml
 │       └── production.auto.tfvars
 │       └── main.tf
 └── test
     └── terraform
-        └── bitops.config.yml
+        └── bitops.config.yaml
         └── test.auto.tfvars
 ```
 
@@ -52,7 +52,7 @@ Before default merge
 │       └── main.tf
 └── test
     └── terraform
-        └── bitops.config.yml
+        └── bitops.config.yaml
         └── main.tf
 ```
 After default merge
@@ -62,7 +62,7 @@ After default merge
 │       └── main.tf
 └── test
     └── terraform
-        └── bitops.config.yml
+        └── bitops.config.yaml
         └── main.tf.test.tf
         └── main.tf # This comes from default/terraform/main.tf
 ```
@@ -87,7 +87,7 @@ Before default merge
 │       │   └── default-after-script.sh
 └── test
     └── terraform
-        └── bitops.config.yml
+        └── bitops.config.yaml
         └── main.tf
 ```
 After default merge

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -3,7 +3,7 @@
 ## Lifecycle hooks
 Within each tool directory, you can optionally have a `bitops.before-deploy.d/` and/or a `bitops.after-deploy.d/`. If any shell scripts exist within these directories, bitops will execute them first.
 
-This is a useful way to extend the functionality of bitops. A popular usecase we've seen is loading secrets or dynamically editing `bitops.config.yml`
+This is a useful way to extend the functionality of bitops. A popular usecase we've seen is loading secrets or dynamically editing `bitops.config.yaml`
 
 ## Detailed Execution Flow
 
@@ -21,7 +21,7 @@ Attempts to setup a cloud provider (AWS) using the credentials passed in at cont
 If a `terraform/` directory exists within the selected environment:
 
 * Run any `bitops.before-deploy.d/*.sh` scripts 
-* Load `bitops.config.yml` and set environment
+* Load `bitops.config.yaml` and set environment
 * Merge contents with [Default environment](default-environment.md) - [TODO](https://github.com/bitovi/bitops/issues/18)
 * Select terraform version
 * Run `terraform init`
@@ -35,7 +35,7 @@ If an `ansible/` directory exists within the selected environment:
 
 * Run any `bitops.before-deploy.d/*.sh` scripts
 * Load `ansible/extra_env` environment config file if exists
-* Load `bitops.config.yml` and set environment
+* Load `bitops.config.yaml` and set environment
 * Merge contents with [Default environment](default-environment.md) - [TODO](https://github.com/bitovi/bitops/issues/18)
 * Run `ansible-playbook $playbook` for each `*.yaml` or `*.yml` file in `$env/ansible/` 
 * Run any `bitops.after-deploy.d/*.sh` scripts
@@ -45,7 +45,7 @@ If a `helm/` directory exists within the selected environment:
 
 * Run the following for `$env/helm/$ENVIRONMENT_HELM_SUBDIRECTORY/` or for all charts in `$env/helm/`
 * Run any `bitops.before-deploy.d/*.sh` scripts
-* Load `bitops.config.yml` and set environment
+* Load `bitops.config.yaml` and set environment
 * Merge contents with [Default environment](default-environment.md)
 * Use `$KUBE_CONFIG_PATH` if defined, if not use aws cli to build .kubeconfig
 * Gather all values files - TODO document
@@ -59,7 +59,7 @@ If a `helm/` directory exists within the selected environment:
 If a `cloudformation/` directory exists within the selected environment:
 
 * Run any `bitops.before-deploy.d/*.sh` scripts
-* Load `bitops.config.yml` and set environment
+* Load `bitops.config.yaml` and set environment
 * Merge contents with [Default environment](default-environment.md) - [TODO](https://github.com/bitovi/bitops/issues/18)
 * Run cfn template validation
 * Create or delete cfn stack. Wait for completion

--- a/docs/operations-repo-structure.md
+++ b/docs/operations-repo-structure.md
@@ -5,40 +5,40 @@ BitOps expects an operations repo to be in the following structure
 │   ├── ansible
 │   │   ├── bitops.after-deploy.d
 │   │   ├── bitops.before-deploy.d
-│   │   └── bitops.config.yml
+│   │   └── bitops.config.yaml
 │   ├── cloudformation
 │   │   ├── bitops.after-deploy.d
 │   │   ├── bitops.before-deploy.d
-│   │   └── bitops.config.yml
+│   │   └── bitops.config.yaml
 │   ├── helm
 │   │   ├── chartA
-│   │   │   └── bitops.config.yml
+│   │   │   └── bitops.config.yaml
 │   │   └── chartB
-│   │       └── bitops.config.yml
-│   │   └── bitops.config.yml
+│   │       └── bitops.config.yaml
+│   │   └── bitops.config.yaml
 │   └── terraform
 │       ├── bitops.after-deploy.d
 │       ├── bitops.before-deploy.d
-│       └── bitops.config.yml
+│       └── bitops.config.yaml
 └── test-serviceA
     ├── ansible
     │   ├── bitops.after-deploy.d
     │   ├── bitops.before-deploy.d
-    │   └── bitops.config.yml
+    │   └── bitops.config.yaml
     ├── cloudformation
     │   ├── bitops.after-deploy.d
     │   ├── bitops.before-deploy.d
-    │   └── bitops.config.yml
+    │   └── bitops.config.yaml
     ├── helm
     │   ├── chartA
-    │   │   └── bitops.config.yml
+    │   │   └── bitops.config.yaml
     │   └── chartB
-    │       └── bitops.config.yml
-    │   └── bitops.config.yml
+    │       └── bitops.config.yaml
+    │   └── bitops.config.yaml
     └── terraform
         ├── bitops.after-deploy.d
         ├── bitops.before-deploy.d
-        └── bitops.config.yml
+        └── bitops.config.yaml
 ```
 #### Environment Directories
 These directories live at the root of an operations repository and are used to separate applications and environments. Depending on your usecase, you may have an environment for `production`, `test` and `dev` or these traditional environments may be further separated into individual services. This pattern is preferential to having a branch for each environment as this allows the state of all your infrastructure to be managed from one location without merging potentially breaking an environment.
@@ -61,7 +61,7 @@ chmod +x bitops.before-deploy.d/*
 chmod +x bitops.after-deploy.d/*
 ```
 
-#### bitops.config.yml
-Each tool is traditionally controlled with a set of cli arguements. Instead of defining these cli arguments within your pipeline configuration, these arguements can instead be defined using environment variables or within a `bitops.config.yml` file. While the core schema for this file is common betwen tools, the specific properties and environment variable equivilants vary from tool to tool. See [BitOps Configuration](configuration-base.md) for details.
+#### bitops.config.yaml
+Each tool is traditionally controlled with a set of cli arguements. Instead of defining these cli arguments within your pipeline configuration, these arguements can instead be defined using environment variables or within a `bitops.config.yaml` file. While the core schema for this file is common betwen tools, the specific properties and environment variable equivilants vary from tool to tool. See [BitOps Configuration](configuration-base.md) for details.
 
 

--- a/docs/tool-configuration/configuration-ansible.md
+++ b/docs/tool-configuration/configuration-ansible.md
@@ -1,6 +1,6 @@
 # Ansible
 
-## Example bitops.config.yml
+## Example bitops.config.yaml
 ```
 ansible:
   cli:
@@ -104,7 +104,7 @@ Will run `--list-tasks` but won't actually execute playbook(s)
 Acceptable values `0|1|2|3|4`. Equivalent to adding `-verbose` or repeating `-v` flags. Will override a pre-existing `ANSIBLE_VERBOSITY` environmental variable or `[default]` `verbosity=` setting in ansible.cfg.
 
 ## Additional Environment Variable Configuration
-Although not captured in `bitops.config.yml`, the following environment variables can be set to further customize behaviour.
+Although not captured in `bitops.config.yaml`, the following environment variables can be set to further customize behaviour.
 
 -------------------
 ### EXTRA_ENV

--- a/docs/tool-configuration/configuration-cloudformation.md
+++ b/docs/tool-configuration/configuration-cloudformation.md
@@ -1,6 +1,6 @@
 # Cloudformation
 
-## Example bitops.config.yml
+## Example bitops.config.yaml
 ```
 cloudformation:
   cli:
@@ -123,7 +123,7 @@ The directory within the ansible workspace that contains json files that will be
 -------------------
 
 ## Additional Environment Variable Configuration
-Although not captured in `bitops.config.yml`, the following environment variables can be set to further customize behaviour
+Although not captured in `bitops.config.yaml`, the following environment variables can be set to further customize behaviour
 
 -------------------
 ### SKIP_DEPLOY_CLOUDFORMATION

--- a/docs/tool-configuration/configuration-helm.md
+++ b/docs/tool-configuration/configuration-helm.md
@@ -1,6 +1,6 @@
 # Helm
 
-## Example bitops.config.yml
+## Example bitops.config.yaml
 ```
 helm:
   cli:
@@ -145,7 +145,7 @@ cloud kubernetes cluster name for kubeconfig fetching.
 
 -------------------
 ## Plugin Configuration
-This section of `bitops.config.yml` is unique to helm and allows the customization of helm plugins
+This section of `bitops.config.yaml` is unique to helm and allows the customization of helm plugins
 
 -------------------
 ### S3 Plugin
@@ -169,7 +169,7 @@ AWS s3 bucket name
 
 -------------------
 ## Additional Environment Variable Configuration
-Although not captured in `bitops.config.yml`, the following environment variables can be set to further customize behaviour
+Although not captured in `bitops.config.yaml`, the following environment variables can be set to further customize behaviour
 
 -------------------
 ### SKIP_DEPLOY_HELM

--- a/docs/tool-configuration/configuration-terraform.md
+++ b/docs/tool-configuration/configuration-terraform.md
@@ -1,7 +1,7 @@
 # Terraform
 Terraform will always run `terraform init` and `terraform plan` on every execution.
 
-## Example bitops.config.yml
+## Example bitops.config.yaml
 ```
 terraform:
     cli:
@@ -70,7 +70,7 @@ Will select a terraform workspace using `terraform workspace new $TERRAFORM_WORK
 -------------------
 
 ## Additional Environment Variable Configuration
-Although not captured in `bitops.config.yml`, the following environment variables can be set to further customize behaviour
+Although not captured in `bitops.config.yaml`, the following environment variables can be set to further customize behaviour
 
 -------------------
 ### SKIP_DEPLOY_TERRAFORM


### PR DESCRIPTION
Update the docs to use `.yaml` for bitops config, as that's what we expect from the Docker build:

```
=> ERROR [4/1] COPY bitops.config.yaml .
```
