### PR TITLE
Validation & Error reporting for bitops.config.yam top yaml level

### DIFF
--- a/scripts/plugins/settings.py
+++ b/scripts/plugins/settings.py
@@ -40,6 +40,10 @@ BITOPS_ENV_default_folder   = os.environ.get("BITOPS_DEFAULT_FOLDER_NAME")
 BITOPS_ENV_environment      = os.environ.get("BITOPS_ENVIRONMENT", None)
 BITOPS_ENV_timeout          = os.environ.get("BITOPS_TIMEOUT")
 
+if not bitops_build_configuration.bitops:
+    sys.stderr.write(f"Error: Invalid {BITOPS_config_file}: 'bitops' at the root level definition is required!")
+    sys.exit(1)
+
 # WASHED VALUES
 # This is just stacked ternary operators. Don't be scared. All this does is X if X is set, Y if Y is set, else default value
 BITOPS_fast_fail_mode = BITOPS_ENV_fast_fail_mode                   \
@@ -90,4 +94,4 @@ BITOPS_timeout = BITOPS_ENV_timeout   \
     if BITOPS_ENV_timeout is not None        \
     else bitops_build_configuration.bitops.timeout               \
         if bitops_build_configuration.bitops.timeout is not None \
-        else 600    
+        else 600


### PR DESCRIPTION
When following the plugins doc https://github.com/bitovi/bitops/blob/plugins/docs/plugins.md#creating-your-own-bitops if someone has invalid config `bitops.config.yaml` with missing `bitops` at a root level (could be a typo) it will experience an error like `#8 0.954 AttributeError: 'NoneType' object has no attribute 'fail_fast'` which is confusing.

Looks like validation and error reporting issue.

## Steps to reproduce
Create `bitops.config.yaml`:
```yaml
foo:
  bar
```
`Dockerfile`:
```Dokerfile
FROM bitovi/bitops:plugins-base
```
and run the docker build.


## Error
```sh
docker build . -t custom/bitops:latest                                             1 ✘ 
[+] Building 1.7s (8/8) FINISHED                                                                                        
 => [internal] load build definition from Dockerfile                                                               0.4s
 => => transferring dockerfile: 74B                                                                                0.1s
 => [internal] load .dockerignore                                                                                  0.3s
 => => transferring context: 2B                                                                                    0.0s
 => [internal] load metadata for docker.io/bitovi/bitops:plugins-base                                              0.0s
 => [1/1] FROM docker.io/bitovi/bitops:plugins-base                                                                0.0s
 => [internal] load build context                                                                                  0.1s
 => => transferring context: 1.19kB                                                                                0.0s
 => CACHED [2/1] WORKDIR /opt/bitops                                                                               0.0s
 => CACHED [3/1] COPY bitops.config.yaml .                                                                         0.0s
 => ERROR [4/1] RUN python3 scripts/plugins.py install                                                             1.1s
------                                                                                                                  
 > [4/1] RUN python3 scripts/plugins.py install:                                                                        
#8 0.954 Traceback (most recent call last):                                                                             
#8 0.954   File "scripts/plugins.py", line 4, in <module>                                                               
#8 0.954     import plugins.settings                                                                                    
#8 0.954   File "/opt/bitops/scripts/plugins/settings.py", line 52, in <module>                                         
#8 0.954     if bitops_build_configuration.bitops.fail_fast is not None  \
#8 0.954 AttributeError: 'NoneType' object has no attribute 'fail_fast'
------
executor failed running [/bin/sh -c python3 scripts/plugins.py install]: exit code: 1
```

This PR fixes it at least at a top `bitops` level.

