### PR TITLE
Additional docker tagging for Omnibus and Base

### DIFF
--- a/.github/workflows/build-and-publish-base.yaml
+++ b/.github/workflows/build-and-publish-base.yaml
@@ -87,6 +87,7 @@ jobs:
         DOCKER_USER: ${{ secrets.DOCKERHUB_USERNAME}}
         DOCKER_PASS: ${{ secrets.DOCKERHUB_PASSWORD}}
         IMAGE_TAG: ${{ github.event.release.tag_name }}-base
+        ADDITIONAL_IMAGE_TAG: base
       run: |
         echo "running scripts/ci/publish.sh"
         ./scripts/ci/publish.sh

--- a/.github/workflows/build-and-publish-prebuilt.yaml
+++ b/.github/workflows/build-and-publish-prebuilt.yaml
@@ -18,12 +18,12 @@ on:
   
 jobs:
   publish-prebuilds:
-    name: Publish for ${{ matrix.target }}
+    name: Publish image for ${{ matrix.target }}
     runs-on: ubuntu-latest
     strategy:
       matrix: 
         target:
-          - aws-ansible  
+          - aws-ansible
           - aws-helm
           - aws-terraform
           - omnibus
@@ -61,10 +61,10 @@ jobs:
     #           Workflow dispatch              #
     # ~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~- # 
     # Loads VERSION_TAG from inputs
-    - name: Update VERSION_TAG with input (workflow_disbatch)
+    - name: Update VERSION_TAG with input (workflow_dispatch)
       run: |
         echo "VERSION_TAG=${{ github.event.inputs.image_tag}}" >> $GITHUB_ENV
-      if: github.event_name == 'workflow_disbatch'
+      if: github.event_name == 'workflow_dispatch'
     
     - uses: cuchi/jinja2-action@v1.2.0
       with:
@@ -73,7 +73,7 @@ jobs:
         strict: true
         variables: |
           bitops_base=${{ env.VERSION_TAG }}
-      if: github.event_name == 'workflow_disbatch'
+      if: github.event_name == 'workflow_dispatch'
 
     # ~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~- #
     #                   ALL                    #
@@ -83,7 +83,7 @@ jobs:
       run: |
         cp ./prebuilt-config/${{ matrix.target }}/Dockerfile ./Dockerfile
         cp ./prebuilt-config/${{ matrix.target }}/bitops.config.yaml ./bitops.config.yaml
-                
+
     - name: Publish Docker Image
       env:
         REGISTRY_URL: "bitovi/bitops"

--- a/docs/ci-pipeline.md
+++ b/docs/ci-pipeline.md
@@ -35,7 +35,7 @@ This effectively softlinks the CI pipelines as though they are able to run indep
 
 The push trigger will perform a basic rebuild of the base image but it will not bump the bitops-version, therefor this trigger does not trigger the subsequent prebuilt image CI. 
 
-### **Workflow Disbatch**
+### **Workflow dispatch**
 ```
     # ~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~- #
     #           Workflow dispatch              #
@@ -55,7 +55,7 @@ The push trigger will perform a basic rebuild of the base image but it will not 
       if: github.event_name == 'workflow_dispatch'
 ```
 
-The workflow disbatch trigger will create a custom bitops image name, and provides the boolean option to bump the [prebuilt-config/bitops-tag.yaml](../prebuilt-config/bitops-tag.yaml)`:tags.bitops-tag`
+The workflow dispatch trigger will create a custom bitops image name, and provides the boolean option to bump the [prebuilt-config/bitops-tag.yaml](../prebuilt-config/bitops-tag.yaml)`:tags.bitops-tag`
 
 
 ### **Release**
@@ -85,5 +85,5 @@ Creates a new base image based on the tag of the release and bumps the [prebuilt
 ### **Push**
 The CI pipeline watches the [prebuilt-config/bitops-tag.yaml](../prebuilt-config/bitops-tag.yaml) file and if an update occurs to the `tags.bitops_base` tag then it rebuilds using the new version.
 
-### **Workflow Disbatch**
-The user who triggers the workflow disbatch must specify a image tag for the plugins image name. For example if `2.0.0` was entered as the `image_tag` then a resulting image would be; `2.0.0-<tool>`. The value of tool is determined from the CI matrix within the [build-and-publish-prebuilt.yaml](../.github/workflows/build-and-publish-prebuilt.yaml)
+### **Workflow dispatch**
+The user who triggers the workflow dispatch must specify a image tag for the plugins image name. For example if `2.0.0` was entered as the `image_tag` then a resulting image would be; `2.0.0-<tool>`. The value of tool is determined from the CI matrix within the [build-and-publish-prebuilt.yaml](../.github/workflows/build-and-publish-prebuilt.yaml)

--- a/scripts/ci/publish.sh
+++ b/scripts/ci/publish.sh
@@ -39,7 +39,7 @@ if [[ "${IMAGE_TAG:0:1}" == "v" ]]; then
   IMAGE_TAG="${IMAGE_TAG:1}"
 fi
 
-if echo "$IMAGE_TAG" | grep '\d.\d.\d-omnibus'; then
+if echo "$IMAGE_TAG" | grep 'omnibus$'; then
   if [ "$TAG_OR_HEAD" == "tags" ]; then # a release
     ADDITIONAL_IMAGE_TAG="latest"
   elif [ "$TAG_OR_HEAD" == "heads" ] && [ "$BRANCH_OR_TAG_NAME" == "$DEFAULT_BRANCH" ]; then # merge to default branch

--- a/scripts/ci/publish.sh
+++ b/scripts/ci/publish.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Validation
-: ${REGISTRY_URL:? REGISTRY_URL env is required!}
+: ${REGISTRY_URL:? REGISTRY_URL env variable is required!}
 : ${IMAGE_TAG:? IMAGE_TAG env variable is required!}
 
 # Docker login
@@ -34,7 +34,10 @@ echo "BRANCH_OR_TAG_NAME: $BRANCH_OR_TAG_NAME"
 # if default `main` branch merge, use `dev`
 # See: https://github.com/bitovi/bitops/wiki/BitOps-Image#versioning
 
-# TODO: Remove "v" prefix before the version
+# Remove "v" prefix before the version
+if [[ "${IMAGE_TAG:0:1}" == "v" ]]; then
+  IMAGE_TAG="${IMAGE_TAG:1}"
+fi
 
 if echo "$IMAGE_TAG" | grep '\d.\d.\d-omnibus'; then
   if [ "$TAG_OR_HEAD" == "tags" ]; then # a release


### PR DESCRIPTION
- on a versioned release `1.2.3` and the image name `1.2.3-omnibus`, add the `latest` tag
- on a versioned release `1.2.3` and the image name `1.2.3-base`, add the `base` tag
- on push to the `main` branch (PR merge), - tag the `omnibus` image as `dev`
- remove `v` prefix from the `v1.2.3-image` when docker tagging
- fixes workflow typo `workflow_disbatch` -> `workflow_dispatch`, which would fail otherwise