### PR TITLE
closes #252 - remove plugin and deployment config from base

### DIFF
--- a/bitops.config.yaml
+++ b/bitops.config.yaml
@@ -14,25 +14,9 @@ bitops:
     err: bitops.logs          # error logs filename
     path: /var/logs/bitops    # path to log folder
   opsrepo_root_default_dir: _default
-  plugins:    
-    aws:
-      source: https://github.com/bitops-plugins/aws
-    terraform:
-      source: https://github.com/bitops-plugins/terraform
-    cloudformation:
-      source: https://github.com/bitops-plugins/cloudformation
-    helm:
-      source: https://github.com/bitops-plugins/helm
-    kubectl:
-      source: https://github.com/bitops-plugins/kubectl
-    ansible:
-      source: https://github.com/bitops-plugins/ansible
-  deployments:
-    cloudformation:
-      plugin: cloudformation
-    terraform:
-      plugin: terraform
-    helm:
-      plugin: helm
-    ansible:
-      plugin: ansible
+
+  # https://bitovi.github.io/bitops/plugins/#bitopsconfigyaml
+  plugins: {}
+
+  # https://bitovi.github.io/bitops/plugins/#bitopsconfigyaml
+  deployments: {}


### PR DESCRIPTION
# Description

Removes plugin and deployments from `bitops.config.yaml` for base

Fixes #252 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?
Local docker build to ensure it still works.

It turns out that `ONBUILD RUN` doesn't take effect for the image created from the Dockerfile in which `ONBUILD` is defined, and the only place in the base Dockerfile where the plugin config is referenced is in the install file (called from `ONBUILD`)

In other words, even though the plugins were defined in the base bitops config, they weren't actually being installed.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
