### PR TITLE
Fix 'base' image docker tagging

### DIFF
--- a/.github/workflows/build-and-publish-base.yaml
+++ b/.github/workflows/build-and-publish-base.yaml
@@ -14,8 +14,7 @@ on:
         default: false
 
   push:
-    # TODO: Remove debugging
-    branches: [ fix/base-docker-tagging ]
+    branches: [ main ]
     tags:
       - "*"
     paths-ignore:

--- a/.github/workflows/build-and-publish-base.yaml
+++ b/.github/workflows/build-and-publish-base.yaml
@@ -6,7 +6,7 @@ on:
       bitops_base_tag:
         description: Specifies the tag that will be published
         type: string
-        default: plugins-base
+        default: base
         required: true
       bump_base_tag:
         description: Bumps the bitops-tag.yaml file, this will trigger the recreation of the official prebuilt plugins images
@@ -31,7 +31,7 @@ on:
     types: [ published ]
   
 env:
-  BASE_TAG: plugins-base-RC
+  BASE_TAG: base
   
 jobs:
   publish:
@@ -52,7 +52,8 @@ jobs:
         DEFAULT_BRANCH: "plugins"
         DOCKER_USER: ${{ secrets.DOCKERHUB_USERNAME}}
         DOCKER_PASS: ${{ secrets.DOCKERHUB_PASSWORD}}
-        IMAGE_TAG: ${{ env.BASE_TAG}}
+        # On merge to default 'main' branch push current 'dev-base' Docker tag
+        IMAGE_TAG: dev-base
       run: |
         echo "running scripts/ci/publish.sh"
         ./scripts/ci/publish.sh
@@ -87,7 +88,9 @@ jobs:
         DEFAULT_BRANCH: "plugins"
         DOCKER_USER: ${{ secrets.DOCKERHUB_USERNAME}}
         DOCKER_PASS: ${{ secrets.DOCKERHUB_PASSWORD}}
+        # On release push versioned '1.2.3-base' Docker tag
         IMAGE_TAG: ${{ github.event.release.tag_name }}-base
+        # On release update additional 'base' Docker tag to refer to the latest stable base
         ADDITIONAL_IMAGE_TAG: base
       run: |
         echo "running scripts/ci/publish.sh"

--- a/.github/workflows/build-and-publish-base.yaml
+++ b/.github/workflows/build-and-publish-base.yaml
@@ -14,7 +14,8 @@ on:
         default: false
 
   push:
-    branches: [ main ]
+    # TODO: Remove debugging
+    branches: [ fix/base-docker-tagging ]
     tags:
       - "*"
     paths-ignore:

--- a/scripts/ci/publish.sh
+++ b/scripts/ci/publish.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+###
+# This script is used by CI/CD workflows to build, tag and push docker images to the Docker Hub.
+# It may route, rename or tag the Docker images depending on the current branch or build environment.
+###
 
 set -e
 
@@ -8,10 +12,10 @@ set -e
 
 # Docker login
 echo "$DOCKER_PASS" | docker login --username="$DOCKER_USER" --password-stdin
-echo "logged into dockerhub registry"
+echo -e "\033[32mSuccessfully logged into Docker Hub Registry!\033[0m"
 
 ###
-### PUBLISH - environment setup
+# Environment setup
 ###
 
 # Defining the Default branch variable
@@ -47,9 +51,9 @@ if echo "$IMAGE_TAG" | grep 'omnibus$'; then
   fi
 fi
 
-echo "###"
-echo "### PUBLISH DOCKER"
-echo "###"
+###
+# DOCKER Build & Publish
+###
 
 echo -e "\033[32mBuilding the docker image \033[1m${REGISTRY_URL}:${IMAGE_TAG}\033[0m\033[32m...\033[0m"
 docker build -t ${REGISTRY_URL}:${IMAGE_TAG} .

--- a/scripts/ci/publish.sh
+++ b/scripts/ci/publish.sh
@@ -47,40 +47,20 @@ if echo "$IMAGE_TAG" | grep 'omnibus$'; then
   fi
 fi
 
-# If an IMAGE_PREFIX is not NULL
-if [ -n "$IMAGE_PREFIX" ]; then
-  export IMAGE_TAG="$IMAGE_PREFIX-$IMAGE_TAG"
-fi
-
 echo "###"
 echo "### PUBLISH DOCKER"
 echo "###"
 
-# Defining the Image name variable
-IMAGE_NAME="$REPO_NAME"
+echo -e "\033[32mBuilding the docker image \033[1m${REGISTRY_URL}:${IMAGE_TAG}\033[0m\033[32m...\033[0m"
+docker build -t ${REGISTRY_URL}:${IMAGE_TAG} .
 
-# Building the docker image...
-echo "Building the docker image"
-docker build -t ${IMAGE_NAME} .
-
-# docker image deploy function
-echo "docker tag ${IMAGE_NAME} ${REGISTRY_URL}:${IMAGE_TAG}"
-docker tag ${IMAGE_NAME} ${REGISTRY_URL}:${IMAGE_TAG}
-
-echo "Pushing the docker image to the repository..."
+echo -e "\033[32mPushing the docker image \033[1m${REGISTRY_URL}:${IMAGE_TAG}\033[0m\033[32m to the repository...\033[0m"
 docker push ${REGISTRY_URL}:${IMAGE_TAG}
 
 if [ -n "$ADDITIONAL_IMAGE_TAG" ]; then
-  if [ -n "$IMAGE_PREFIX" ]; then
-    export IMAGE_TAG="$IMAGE_PREFIX-$ADDITIONAL_IMAGE_TAG"
-  else
-    export IMAGE_TAG="$ADDITIONAL_IMAGE_TAG"
-  fi
-  
-  # docker image deploy function
-  echo "docker tag ${IMAGE_NAME} ${REGISTRY_URL}:${IMAGE_TAG}"
-  docker tag ${IMAGE_NAME} ${REGISTRY_URL}:${IMAGE_TAG}
+  echo -e "\033[32mAdding the additional docker tag \033[1m${REGISTRY_URL}:${ADDITIONAL_IMAGE_TAG}\033[0m"
+  docker tag ${REGISTRY_URL}:${IMAGE_TAG} ${REGISTRY_URL}:${ADDITIONAL_IMAGE_TAG}
 
-  echo "Pushing the additional docker image to the repository..."
-  docker push ${REGISTRY_URL}:${IMAGE_TAG}
+  echo -e "\033[32mPushing the additional docker image \033[1m${REGISTRY_URL}:${ADDITIONAL_IMAGE_TAG}\033[0m\033[32m to the repository...\033[0m"
+  docker push ${REGISTRY_URL}:${ADDITIONAL_IMAGE_TAG}
 fi


### PR DESCRIPTION
1) Fix naming in the workflows so on merge to the default `main` branch we push current `dev-base` Docker tag.
Looks like we relied on some old values like `plugins-base-RC`

2) Some visualisation improvements to colorise the docker deploy script messages with green in CI, otherwise it's hard to figure out the exact tags built and pushed
![image](https://user-images.githubusercontent.com/1533818/183675203-daa50d9e-1a11-46ab-85ef-bc9b0c8ddb73.png)
