### PR TITLE
Build and deploy 'dev' image for omnibus

### DIFF
--- a/.github/workflows/build-and-publish-prebuilt.yaml
+++ b/.github/workflows/build-and-publish-prebuilt.yaml
@@ -30,7 +30,8 @@ jobs:
         template: prebuilt-config/dockerfile.template
         output_file: ./Dockerfile
         variables: |
-          tags={"bitops_base": "dev-base"}
+          tags=""
+          tags.bitops_base=dev-base
     - name: Copy bitops.config.yaml into the project root folder
       run: cp ./prebuilt-config/omnibus/bitops.config.yaml ./bitops.config.yaml
     - name: Publish Omnibus dev Docker Image (Push)

--- a/.github/workflows/build-and-publish-prebuilt.yaml
+++ b/.github/workflows/build-and-publish-prebuilt.yaml
@@ -31,7 +31,7 @@ jobs:
         output_file: ./Dockerfile
         strict: true
         variables: |
-          bitops_base=dev-base
+          tags.bitops_base=dev-base
     - name: Copy bitops.config.yaml into the project root folder
       run: cp ./prebuilt-config/omnibus/bitops.config.yaml ./bitops.config.yaml
     - name: Publish Omnibus dev Docker Image (Push)

--- a/.github/workflows/build-and-publish-prebuilt.yaml
+++ b/.github/workflows/build-and-publish-prebuilt.yaml
@@ -9,8 +9,7 @@ on:
         default: base
         required: true
   push:
-    # TODO: Remove debugging
-    branches: [ main, fix/omnibus-dev-image ]
+    branches: [ main ]
     tags:
       - "*"
     paths:
@@ -18,10 +17,10 @@ on:
       - ".github/workflows/build-and-publish-prebuilt.yaml"
 
 jobs:
+  # Separated workflow, as 'bitops-tags.yaml' values could be overwriten
   build-publish-dev:
-    name: Build and push 'dev' omnibus Docker image
+    name: Build and publish 'dev' omnibus Docker image
     runs-on: ubuntu-latest
-    # TODO: Replace branch with 'main'
     if: github.event_name == 'push'
     steps:
     - uses: actions/checkout@v2
@@ -29,7 +28,7 @@ jobs:
       with:
         template: prebuilt-config/dockerfile.template
         output_file: ./Dockerfile
-        variables: tags=""
+        variables: tags="" # uses jinja default from the dockerfile.template
     - name: Copy bitops.config.yaml into the project root folder
       run: cp ./prebuilt-config/omnibus/bitops.config.yaml ./bitops.config.yaml
     - name: Publish Omnibus dev Docker Image (Push)
@@ -37,13 +36,13 @@ jobs:
         REGISTRY_URL: "bitovi/bitops"
         DOCKER_USER: ${{ secrets.DOCKERHUB_USERNAME}}
         DOCKER_PASS: ${{ secrets.DOCKERHUB_PASSWORD}}
-        # 'main' branch 'omnibus' build, publish 'dev' Docker tag
+        # on 'main' branch build 'omnibus' image and publish it as 'dev' Docker tag
         IMAGE_TAG: dev
       run: |
         echo "running scripts/ci/publish.sh"
         ./scripts/ci/publish.sh
 
-  publish-prebuilds:
+  build-publish-prebuilds:
     name: Publish image for ${{ matrix.target }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/build-and-publish-prebuilt.yaml
+++ b/.github/workflows/build-and-publish-prebuilt.yaml
@@ -29,9 +29,7 @@ jobs:
       with:
         template: prebuilt-config/dockerfile.template
         output_file: ./Dockerfile
-        strict: true
-        variables: |
-          tags.bitops_base=dev-base
+    - run: echo ./Dockerfile
     - name: Copy bitops.config.yaml into the project root folder
       run: cp ./prebuilt-config/omnibus/bitops.config.yaml ./bitops.config.yaml
     - name: Publish Omnibus dev Docker Image (Push)

--- a/.github/workflows/build-and-publish-prebuilt.yaml
+++ b/.github/workflows/build-and-publish-prebuilt.yaml
@@ -29,8 +29,9 @@ jobs:
       with:
         template: prebuilt-config/dockerfile.template
         output_file: ./Dockerfile
+        strict: true
         variables: |
-          tags.bitops_base=dev-base
+          bitops_base=dev-base
     - name: Copy bitops.config.yaml into the project root folder
       run: cp ./prebuilt-config/omnibus/bitops.config.yaml ./bitops.config.yaml
     - name: Publish Omnibus dev Docker Image (Push)

--- a/.github/workflows/build-and-publish-prebuilt.yaml
+++ b/.github/workflows/build-and-publish-prebuilt.yaml
@@ -29,9 +29,7 @@ jobs:
       with:
         template: prebuilt-config/dockerfile.template
         output_file: ./Dockerfile
-        variables: |
-          tags=""
-          tags.bitops_base=dev-base
+        variables: tags=""
     - name: Copy bitops.config.yaml into the project root folder
       run: cp ./prebuilt-config/omnibus/bitops.config.yaml ./bitops.config.yaml
     - name: Publish Omnibus dev Docker Image (Push)

--- a/.github/workflows/build-and-publish-prebuilt.yaml
+++ b/.github/workflows/build-and-publish-prebuilt.yaml
@@ -6,9 +6,10 @@ on:
       image_tag:
         description: Specifies the tag that will be published
         type: string
-        default: plugins
+        default: base
         required: true
   push:
+    # TODO: Remove debugging
     branches: [ main, fix/omnibus-dev-image ]
     tags:
       - "*"
@@ -17,6 +18,32 @@ on:
       - ".github/workflows/build-and-publish-prebuilt.yaml"
 
 jobs:
+  build-publish-dev:
+    name: Build and push 'dev' omnibus Docker image
+    runs-on: ubuntu-latest
+    # TODO: Replace branch with 'main'
+    if: {{ github.event_name == 'push' && github.ref == 'ref/head/fix/omnibus-dev-image' }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: cuchi/jinja2-action@v1.2.0
+      with:
+        template: prebuilt-config/dockerfile.template
+        output_file: ./Dockerfile
+        variables: |
+          bitops_base=dev-base
+    - name: Copy bitops.config.yaml into the project root folder
+      run: cp ./prebuilt-config/omnibus/bitops.config.yaml ./bitops.config.yaml
+    - name: Publish Omnibus dev Docker Image (Push)
+      env:
+        REGISTRY_URL: "bitovi/bitops"
+        DOCKER_USER: ${{ secrets.DOCKERHUB_USERNAME}}
+        DOCKER_PASS: ${{ secrets.DOCKERHUB_PASSWORD}}
+        # 'main' branch 'omnibus' build, publish 'dev' Docker tag
+        IMAGE_TAG: dev
+      run: |
+        echo "running scripts/ci/publish.sh"
+        ./scripts/ci/publish.sh
+
   publish-prebuilds:
     name: Publish image for ${{ matrix.target }}
     runs-on: ubuntu-latest
@@ -56,7 +83,7 @@ jobs:
         data_file: prebuilt-config/bitops-tag.yaml
         data_format: yaml
       if: github.event_name == 'push'
-  
+
     # ~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~- #
     #           Workflow dispatch              #
     # ~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~- # 
@@ -65,7 +92,7 @@ jobs:
       run: |
         echo "VERSION_TAG=${{ github.event.inputs.image_tag}}" >> $GITHUB_ENV
       if: github.event_name == 'workflow_dispatch'
-    
+
     - uses: cuchi/jinja2-action@v1.2.0
       with:
         template: prebuilt-config/dockerfile.template
@@ -84,22 +111,12 @@ jobs:
         cp ./prebuilt-config/${{ matrix.target }}/Dockerfile ./Dockerfile
         cp ./prebuilt-config/${{ matrix.target }}/bitops.config.yaml ./bitops.config.yaml
 
-    - name: Publish Docker Image (Push)
-      env:
-        REGISTRY_URL: "bitovi/bitops"
-        DOCKER_USER: ${{ secrets.DOCKERHUB_USERNAME}}
-        DOCKER_PASS: ${{ secrets.DOCKERHUB_PASSWORD}}
-        IMAGE_TAG: dev
-      run: |
-        echo "running scripts/ci/publish.sh"
-        ./scripts/ci/publish.sh
-      if: github.event_name == 'push' && matrix.target == 'omnibus'
-
     - name: Publish Docker Image (Release)
       env:
         REGISTRY_URL: "bitovi/bitops"
         DOCKER_USER: ${{ secrets.DOCKERHUB_USERNAME}}
         DOCKER_PASS: ${{ secrets.DOCKERHUB_PASSWORD}}
+        # On a versioned release push '2.0.0-omnibus', '2.0.0-aws-ansible', etc Docker tags
         IMAGE_TAG: ${{ env.VERSION_TAG }}-${{ matrix.target }}
       run: |
         echo "running scripts/ci/publish.sh"

--- a/.github/workflows/build-and-publish-prebuilt.yaml
+++ b/.github/workflows/build-and-publish-prebuilt.yaml
@@ -9,13 +9,13 @@ on:
         default: plugins
         required: true
   push:
-    branches: [ plugins ]
+    branches: [ main, fix/omnibus-dev-image ]
     tags:
       - "*"
     paths:
       - "prebuilt-config/bitops-tag.yaml"
       - ".github/workflows/build-and-publish-prebuilt.yaml"
-  
+
 jobs:
   publish-prebuilds:
     name: Publish image for ${{ matrix.target }}
@@ -84,13 +84,24 @@ jobs:
         cp ./prebuilt-config/${{ matrix.target }}/Dockerfile ./Dockerfile
         cp ./prebuilt-config/${{ matrix.target }}/bitops.config.yaml ./bitops.config.yaml
 
-    - name: Publish Docker Image
+    - name: Publish Docker Image (Push)
       env:
         REGISTRY_URL: "bitovi/bitops"
-        DEFAULT_BRANCH: "plugins"
+        DOCKER_USER: ${{ secrets.DOCKERHUB_USERNAME}}
+        DOCKER_PASS: ${{ secrets.DOCKERHUB_PASSWORD}}
+        IMAGE_TAG: dev
+      run: |
+        echo "running scripts/ci/publish.sh"
+        ./scripts/ci/publish.sh
+      if: github.event_name == 'push' && matrix.target == 'omnibus'
+
+    - name: Publish Docker Image (Release)
+      env:
+        REGISTRY_URL: "bitovi/bitops"
         DOCKER_USER: ${{ secrets.DOCKERHUB_USERNAME}}
         DOCKER_PASS: ${{ secrets.DOCKERHUB_PASSWORD}}
         IMAGE_TAG: ${{ env.VERSION_TAG }}-${{ matrix.target }}
       run: |
         echo "running scripts/ci/publish.sh"
         ./scripts/ci/publish.sh
+      if: github.event_name == 'release'

--- a/.github/workflows/build-and-publish-prebuilt.yaml
+++ b/.github/workflows/build-and-publish-prebuilt.yaml
@@ -29,7 +29,8 @@ jobs:
       with:
         template: prebuilt-config/dockerfile.template
         output_file: ./Dockerfile
-    - run: echo ./Dockerfile
+        variables: |
+          tags={"bitops_base": "dev-base"}
     - name: Copy bitops.config.yaml into the project root folder
       run: cp ./prebuilt-config/omnibus/bitops.config.yaml ./bitops.config.yaml
     - name: Publish Omnibus dev Docker Image (Push)

--- a/.github/workflows/build-and-publish-prebuilt.yaml
+++ b/.github/workflows/build-and-publish-prebuilt.yaml
@@ -22,7 +22,7 @@ jobs:
     name: Build and push 'dev' omnibus Docker image
     runs-on: ubuntu-latest
     # TODO: Replace branch with 'main'
-    if: github.event_name == 'push' && github.ref == 'ref/head/fix/omnibus-dev-image'
+    if: github.event_name == 'push'
     steps:
     - uses: actions/checkout@v2
     - uses: cuchi/jinja2-action@v1.2.0

--- a/.github/workflows/build-and-publish-prebuilt.yaml
+++ b/.github/workflows/build-and-publish-prebuilt.yaml
@@ -22,7 +22,7 @@ jobs:
     name: Build and push 'dev' omnibus Docker image
     runs-on: ubuntu-latest
     # TODO: Replace branch with 'main'
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.ref == 'ref/head/fix/omnibus-dev-image'
     steps:
     - uses: actions/checkout@v2
     - uses: cuchi/jinja2-action@v1.2.0
@@ -30,7 +30,7 @@ jobs:
         template: prebuilt-config/dockerfile.template
         output_file: ./Dockerfile
         variables: |
-          bitops_base=dev-base
+          tags.bitops_base=dev-base
     - name: Copy bitops.config.yaml into the project root folder
       run: cp ./prebuilt-config/omnibus/bitops.config.yaml ./bitops.config.yaml
     - name: Publish Omnibus dev Docker Image (Push)

--- a/.github/workflows/build-and-publish-prebuilt.yaml
+++ b/.github/workflows/build-and-publish-prebuilt.yaml
@@ -22,7 +22,7 @@ jobs:
     name: Build and push 'dev' omnibus Docker image
     runs-on: ubuntu-latest
     # TODO: Replace branch with 'main'
-    if: {{ github.event_name == 'push' && github.ref == 'ref/head/fix/omnibus-dev-image' }}
+    if: github.event_name == 'push'
     steps:
     - uses: actions/checkout@v2
     - uses: cuchi/jinja2-action@v1.2.0

--- a/prebuilt-config/bitops-tag.yaml
+++ b/prebuilt-config/bitops-tag.yaml
@@ -1,3 +1,3 @@
 tags:
-  bitops_base: plugins-base-RC
+  bitops_base: base
   plugins_base: plugins

--- a/prebuilt-config/dockerfile.template
+++ b/prebuilt-config/dockerfile.template
@@ -1,1 +1,1 @@
-FROM bitovi/bitops:{{ tags.bitops_base | default("dev-base") }}
+FROM bitovi/bitops:{{ tags.bitops_base }}

--- a/prebuilt-config/dockerfile.template
+++ b/prebuilt-config/dockerfile.template
@@ -1,1 +1,1 @@
-FROM bitovi/bitops:{{ tags.bitops_base }}
+FROM bitovi/bitops:{{ tags.bitops_base | default("dev-base") }}


### PR DESCRIPTION
- On every push to `main` branch build current `omnibus` image and publish it as `bitops:dev` Docker tag
- It should be done `FROM bitovi/bitops:dev-base` Docker image already built and deployed for the `main` branch (#265)

added it as a separated job as I can't rely on existing pipeline reading the `bitops-tag.yaml` that could be overridden.