### PR TITLE
Fix missing ENVIRONMENT -> BITOPS_ENVIRONMENT var changes in the docs

### DIFF
--- a/docs/configuration-base.md
+++ b/docs/configuration-base.md
@@ -51,7 +51,7 @@ If true, [file mergers](default-environment.md) will replace instead of create a
 * **default:** `""`
 * **required:** no
 
-If nonempty, will evaluate the `git diff` to see if there are any changes in the specified `ENVIRONMENT` and will `exit 0` if not.
+If nonempty, will evaluate the `git diff` to see if there are any changes in the specified `BITOPS_ENVIRONMENT` and will `exit 0` if not.
 
 -------------------
 ## Cloud Providers

--- a/docs/default-environment.md
+++ b/docs/default-environment.md
@@ -17,7 +17,7 @@ Suppose we are working with an operations repo that is exlusviely terraform. We 
         └── bitops.config.yaml
         └── test.auto.tfvars
 ```
-When `$ENVIRONMENT` is set to `production`, `default/` will be merged in to `production/` at runtime to produce a directory structure that looks like
+When `$BITOPS_ENVIRONMENT` is set to `production`, `_default/` will be merged in to `production/` at runtime to produce a directory structure that looks like
 ```
 ├── _default
 │   └── terraform
@@ -40,9 +40,9 @@ Things get more complex when files exist in both the `_default` and `active` env
 Different files have different behvaviors based on the file extension + the deployment tool. Some files can be merged together, others can't. This behavior is defined below.
 
 ### `.tf` (HCL) Handling
-Files that only exist in the `default` environment will be copied over.
+Files that only exist in the `_default` environment will be copied over.
 
-`.tf` files from the `default` environment that share its name and path with a file in the active environment will both be in the resulting directory with the active environment name having a suffix added to it.
+`.tf` files from the `_default` environment that share its name and path with a file in the active environment will both be in the resulting directory with the active environment name having a suffix added to it.
 
 #### Example
 Before default merge
@@ -74,9 +74,9 @@ rsync -ab --suffix ".${ENV_DIR}.tf" --include="*/" --include="*.tf" --exclude="*
 ```
 
 ### .sh Handling
-Files that only exist in the `default` environment will be copied over.
+Files that only exist in the `_default` environment will be copied over.
 
-`.sh` files from the `default` environment that share its name and path with a file in the active environment will not be copied over.
+`.sh` files from the `_default` environment that share its name and path with a file in the active environment will not be copied over.
 
 #### Example
 Before default merge

--- a/docs/development-local.md
+++ b/docs/development-local.md
@@ -4,7 +4,7 @@ At this point you should have a repo for your custom BitOps image and have it op
 ## Create a plugins.dockerfile
 Create a file in the root level of BitOps named `Dockerfile.plugins` with the content; 
 
-`FROM bitovi/bitops:2.0.0-omnibus`
+`FROM bitovi/bitops:2.0.0`
 
 
 ## Build BitOps (with plugins)

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -54,7 +54,7 @@ export AWS_SECRET_ACCESS_KEY=ZYXWV09876
 export AWS_DEFAULT_REGION=us-east-1
 export MY_VAR1=value1
 docker run \
--e ENVIRONMENT="ansible-operations-repo" \
+-e BITOPS_ENVIRONMENT="ansible-operations-repo" \
 -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
 -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
 -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION \
@@ -75,7 +75,7 @@ A `*` denotes a required variable.
 | Variable          | Value                             |  Notes     |
 |   :---            |   :---                            |    :---    |
 | `$BITOPS_DIR`     | `/opt/bitops`                     |   Within the container the default working directory for BitOps        |
-| `$ENVIRONMENT`*   | `YOUR_OPS_REPO_ENVIRONMENT`                   |   BitOps requires at least one environment folder to be specified at container execution.   |
+| `$BITOPS_ENVIRONMENT`*   | `YOUR_OPS_REPO_ENVIRONMENT`                   |   BitOps requires at least one environment folder to be specified at container execution.   |
 | `$ENVROOT`        | `$TEMPDIR/$ENVIRONMENT`           |   e.g `/tmp/tmp.RANDOM/YOUR_OPS_REPO_ENVIRONMENT`  |
 | `$TEMPDIR`        | `/tmp/tmp.RANDOM`                  |   This is the randomly generated working dir for BitOps.  |
 | `$ROOT_DIR`        | `/opt/bitops_deployment`                  |   This working dir for BitOps (moved to `$TEMPDIR` during execution)  |

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -9,7 +9,7 @@ For complete code samples see [https://github.com/bitovi/bitops/tree/master/docs
 An environment must always be selected
 ```
 docker run \
--e ENVIRONMENT="dev" \
+-e BITOPS_ENVIRONMENT="dev" \
 -v $(pwd):/opt/bitops_deployment \
 bitovi/bitops:latest
 ```
@@ -17,7 +17,7 @@ bitovi/bitops:latest
 ### AWS Config
 ```
 docker run \
--e ENVIRONMENT="dev" \
+-e BITOPS_ENVIRONMENT="dev" \
 -e AWS_ACCESS_KEY_ID=<AWS_SECRET_ACCESS_KEY> \
 -e AWS_SECRET_ACCESS_KEY=<AWS_SECRET_ACCESS_KEY> \
 -e AWS_DEFAULT_REGION="us-east-1" \
@@ -28,7 +28,7 @@ bitovi/bitops:latest
 ### Passing in kubeconfig
 ```
 docker run \
--e ENVIRONMENT="dev" \
+-e BITOPS_ENVIRONMENT="dev" \
 -e AWS_ACCESS_KEY_ID=<AWS_SECRET_ACCESS_KEY> \
 -e AWS_SECRET_ACCESS_KEY=<AWS_SECRET_ACCESS_KEY> \
 -e AWS_DEFAULT_REGION="us-east-1" \
@@ -41,7 +41,7 @@ bitovi/bitops:latest
 If you has a cluster arn of `arn:aws:eks:us-east-1:111122223333:cluster/my-cluster`, you would use the following configuration
 ```
 docker run \
--e ENVIRONMENT="dev" \
+-e BITOPS_ENVIRONMENT="dev" \
 -e AWS_ACCESS_KEY_ID=<AWS_SECRET_ACCESS_KEY> \
 -e AWS_SECRET_ACCESS_KEY=<AWS_SECRET_ACCESS_KEY> \
 -e AWS_DEFAULT_REGION="us-east-1" \
@@ -54,7 +54,7 @@ bitovi/bitops:latest
 If there is a `dev/ansible/` directory, ansible execution can be skipped with `SKIP_DEPLOY_ANSIBLE`
 ```
 docker run \
--e ENVIRONMENT="dev" \
+-e BITOPS_ENVIRONMENT="dev" \
 -e AWS_ACCESS_KEY_ID=<AWS_SECRET_ACCESS_KEY> \
 -e AWS_SECRET_ACCESS_KEY=<AWS_SECRET_ACCESS_KEY> \
 -e AWS_DEFAULT_REGION="us-east-1" \
@@ -66,7 +66,7 @@ bitovi/bitops:latest
 ### Force call terraform destroy
 ```
 docker run \
--e ENVIRONMENT="dev" \
+-e BITOPS_ENVIRONMENT="dev" \
 -e AWS_ACCESS_KEY_ID=<AWS_SECRET_ACCESS_KEY> \
 -e AWS_SECRET_ACCESS_KEY=<AWS_SECRET_ACCESS_KEY> \
 -e AWS_DEFAULT_REGION="us-east-1" \
@@ -81,7 +81,7 @@ docker run
 -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION           \
 -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID             \
 -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY     \
--e ENVIRONMENT="test"                               \
+-e BITOPS_ENVIRONMENT="test"                               \
 -v $(pwd):/opt/bitops_deployment                    \
 -v $BITOPS_HOME:/opt/bitops                         \
 bitovi/bitops:latest

--- a/docs/operations-repo-structure.md
+++ b/docs/operations-repo-structure.md
@@ -43,7 +43,7 @@ BitOps expects an operations repo to be in the following structure, where each e
 #### Environment Directories
 These directories live at the root of an operations repository and are used to separate applications and environments. Depending on your usecase, you may have an environment for `production`, `test` and `dev` or these traditional environments may be further separated into individual services such as `test_service_a` and `test_serice_b`. This pattern is preferential to having a branch for each environment as this allows the state of all your infrastructure to be managed from one location without merging potentially breaking an environment.
 
-When running BitOps, you provide the environment variable `ENVIRONMENT`. This tells BitOps what environment to work in for that run. A full CI/CD pipeline may call BitOps multiple times if it requires one environment to run as a pre-requisite for another.
+When running BitOps, you provide the environment variable `BITOPS_ENVIRONMENT`. This tells BitOps what environment to work in for that run. A full CI/CD pipeline may call BitOps multiple times if it requires one environment to run as a pre-requisite for another.
 
 #### Environment Directory Naming Convention
 Sometimes it is useful to have directories in your operations repo that are not deployable environments such as common scripts that can be referenced from any environment's [before or after hooks](lifecycle.md).


### PR DESCRIPTION
In `v2.0.0` the use of `$ENVIRONMENT` var was deprecated in favor of `$BITOPS_ENVIRONMENT`.
The documentation is still having the old variable references.

This PR fixes it.

---
@mickmcgrath13 @ccapell @PhillypHenning Another question is what to do with the example projects under the docs https://github.com/bitovi/bitops/tree/main/docs/examples as they might be relying on v1.0 env variables and configuration.
Do we want to rename those too or more verifications on compatibility with v2 needed?