### PR TITLE
Add GH Discussions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![LICENSE](https://img.shields.io/badge/license-MIT-green)](LICENSE.md)
 [![Latest Release](https://img.shields.io/github/v/release/bitovi/bitops)](https://github.com/bitovi/bitops/releases)
+[![GitHub Discussions](https://img.shields.io/github/discussions/bitovi/bitops)](https://github.com/bitovi/bitops/discussions)
 [![Join our Slack](https://img.shields.io/badge/slack-join%20chat-611f69.svg)](https://www.bitovi.com/community/slack?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ### tl;dr

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,9 +19,10 @@ hide:
         <nl>Consistently Deploy.</h1>
         <a class="md-button md-button--primary" href="getting-started">Show me how</a>
         <p>
-            <a href="https://github.com/bitovi/bitops/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/bitovi/bitops"></a>
-            <a href="https://www.bitovi.com/community/slack?utm_source=badge&amp;utm_medium=badge&amp;utm_campaign=pr-badge&amp;utm_content=badge"><img alt="Join our Slack" src="https://img.shields.io/badge/slack-join%20chat-611f69.svg"></a>
             <a href="license/"><img alt="LICENSE" src="https://img.shields.io/badge/license-MIT-green"></a>
+            <a href="https://github.com/bitovi/bitops/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/bitovi/bitops"></a>
+            <a href="https://github.com/bitovi/bitops/discussions"><img alt="BitOps Discussions" src="https://img.shields.io/github/discussions/bitovi/bitops"></a>
+            <a href="https://www.bitovi.com/community/slack?utm_source=badge&amp;utm_medium=badge&amp;utm_campaign=pr-badge&amp;utm_content=badge"><img alt="Join our Slack" src="https://img.shields.io/badge/slack-join%20chat-611f69.svg"></a>
             <a class="github-button" href="https://github.com/bitovi/bitops" data-icon="octicon-star" data-show-count="true" aria-label="Star BitOps on GitHub">Star</a>
         </p>
     </div>


### PR DESCRIPTION
A tiny cosmetic change that adds a badge with a counter, linking to BitOps Discussions.
![image](https://user-images.githubusercontent.com/1533818/184151683-5cedabf0-3758-481e-a861-2bb116b47101.png)
