### PR TITLE
Add a deprecation warning for 'ENVIRONMENT' & env fallback

### DIFF
--- a/scripts/plugins/deploy_plugins.py
+++ b/scripts/plugins/deploy_plugins.py
@@ -51,10 +51,20 @@ def Deploy_Plugins():
     os.environ["BITOPS_DEFAULT_ROOT_DIR"] = BITOPS_default_folder
 
     # Global environment evaluation
+    # TODO: Drop support for 'ENVIRONMENT' env var
+    if 'ENVIRONMENT' in os.environ:
+        logger.warning(
+            "'ENVIRONMENT' var is deprecated in v2.0.0 and will be removed in the future versions! "
+            "Use the 'BITOPS_ENVIRONMENT' env var instead!"
+        )
+
     if BITOPS_ENV_environment is None:
-        logger.error("The `BITOPS_ENVIRONMENT` variable must be set... Exiting.\n\t\tFor more information on this issue please checkout our doc [https://bitovi.github.io/bitops/configuration-base/#environment]")
+        logger.error(
+            "The 'BITOPS_ENVIRONMENT' variable must be set! Exiting...\n"
+            "For more information on this issue please check out [https://bitovi.github.io/bitops/configuration-base/#environment]"
+        )
         quit(1)
-    
+
     # Move to temp directory
     if not os.path.isdir(bitops_deployment_dir):
         logger.error("An operations repo needs to be mounted to the Docker container with the path `/opt/bitops_deployment/`... Exiting.\n\t\tFor more information on this issue please checkout our doc [https://bitovi.github.io/bitops/about/#how-bitops-works]")
@@ -69,7 +79,7 @@ def Deploy_Plugins():
     logger.info("\n\n\n~#~#~#~BITOPS DEPLOYMENT CONFIGURATION~#~#~#~            \
             \n\t TEMP_DIR:                [{temp_dir}]                          \
             \n\t DEFAULT_FOLDER_NAME:     [{default_folder_name}]               \
-            \n\t ENVIRONMENT:             [{env}]                               \
+            \n\t BITOPS_ENVIRONMENT:      [{env}]                               \
             \n\t TIMEOUT:                 [{timeout}]                           \
             \n                                                                  \
             \n\t BITOPS_DIR:              [{bitops_dir}]                        \

--- a/scripts/plugins/settings.py
+++ b/scripts/plugins/settings.py
@@ -37,7 +37,9 @@ BITOPS_ENV_logging_level    = os.environ.get("BITOPS_LOGGING_LEVEL")
 BITOPS_ENV_plugin_dir       = os.environ.get("BITOPS_PLUGIN_DIR")
 
 BITOPS_ENV_default_folder   = os.environ.get("BITOPS_DEFAULT_FOLDER")
-BITOPS_ENV_environment      = os.environ.get("BITOPS_ENVIRONMENT", None)
+# v2.0.0: Fallback to 'ENVIRONMENT' in case when 'BITOPS_ENVIRONMENT' is not set
+# TODO: Drop 'ENVIRONMENT' backward-compatibility in the future versions
+BITOPS_ENV_environment      = os.environ.get("BITOPS_ENVIRONMENT", os.environ.get("ENVIRONMENT", None))
 BITOPS_ENV_timeout          = os.environ.get("BITOPS_TIMEOUT")
 
 if not bitops_build_configuration.bitops:


### PR DESCRIPTION
In v2.0.0 the `ENVIRONMENT` was dropped and replaced with `BITOPS_ENVIRONMENT`.

Per discussion in https://github.com/bitovi/bitops/pull/269#issuecomment-1212039438 instead of erroring, we try to guess if the user is still relying on the old var, try to handle it gracefully by injecting the old value into the new `BITOPS_ENVIRONMENT`, and give a Deprecation Warning.