### PR TITLE
Remove inexistent ENV vars from the docs

### DIFF
--- a/docs/configuration-base.md
+++ b/docs/configuration-base.md
@@ -39,14 +39,6 @@ Each BitOps run is done against a single environment. This property tells BitOps
 Base64 encoded `kubeconfig` file. Allows deployment tools to interact with a kubernetes cluster
 
 -------------------
-### skip_if_no_environment_changes
-* **Environment Variable:** `SKIP_IF_NO_ENVIRONMENT_CHANGES`
-* **default:** `""`
-* **required:** no
-
-If nonempty, will evaluate the `git diff` to see if there are any changes in the specified `BITOPS_ENVIRONMENT` and will `exit 0` if not.
-
--------------------
 ## Cloud Providers
 * [AWS](cloud-configuration/configuration-aws.md)
 

--- a/docs/configuration-base.md
+++ b/docs/configuration-base.md
@@ -39,13 +39,6 @@ Each BitOps run is done against a single environment. This property tells BitOps
 Base64 encoded `kubeconfig` file. Allows deployment tools to interact with a kubernetes cluster
 
 -------------------
-### default_replace
-* **Environment Variable:** `BITOPS_DEFAULT_REPLACE`
-* **default:** `false`
-
-If true, [file mergers](default-environment.md) will replace instead of create a copy during a merge
-
--------------------
 ### skip_if_no_environment_changes
 * **Environment Variable:** `SKIP_IF_NO_ENVIRONMENT_CHANGES`
 * **default:** `""`


### PR DESCRIPTION
The documented env vars `BITOPS_DEFAULT_REPLACE` and `SKIP_IF_NO_ENVIRONMENT_CHANGES` are not implemented. Please let me know if they're coded anywhere as I couldn't find any implementation in the history and implementation.

Removing from the docs to avoid any confusion.