### PR TITLE
Fix the prebuilt image push and tagging via manual workflow dispatch

### DIFF
--- a/.github/workflows/build-and-publish-prebuilt.yaml
+++ b/.github/workflows/build-and-publish-prebuilt.yaml
@@ -89,15 +89,15 @@ jobs:
     - name: Update VERSION_TAG with input (workflow_dispatch)
       run: |
         echo "VERSION_TAG=${{ github.event.inputs.image_tag}}" >> $GITHUB_ENV
+        sed -i "s/bitops_base:.*/bitops_base: ${{ github.event.inputs.image_tag}}-base/" ./prebuilt-config/bitops-tag.yaml
       if: github.event_name == 'workflow_dispatch'
 
     - uses: cuchi/jinja2-action@v1.2.0
       with:
         template: prebuilt-config/dockerfile.template
         output_file: prebuilt-config/${{ matrix.target }}/Dockerfile
-        strict: true
-        variables: |
-          bitops_base=${{ env.VERSION_TAG }}
+        data_file: prebuilt-config/bitops-tag.yaml
+        data_format: yaml
       if: github.event_name == 'workflow_dispatch'
 
     # ~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~- #
@@ -109,7 +109,7 @@ jobs:
         cp ./prebuilt-config/${{ matrix.target }}/Dockerfile ./Dockerfile
         cp ./prebuilt-config/${{ matrix.target }}/bitops.config.yaml ./bitops.config.yaml
 
-    - name: Publish Docker Image (Release)
+    - name: Publish Docker Image (Workflow Dispatch)
       env:
         REGISTRY_URL: "bitovi/bitops"
         DOCKER_USER: ${{ secrets.DOCKERHUB_USERNAME}}
@@ -117,6 +117,11 @@ jobs:
         # On a versioned release push '2.0.0-omnibus', '2.0.0-aws-ansible', etc Docker tags
         IMAGE_TAG: ${{ env.VERSION_TAG }}-${{ matrix.target }}
       run: |
+        # Additionally tag versioned 'omnibus' as 'X.Y.Z' and 'latest' 
+        if [[ "${{ matrix.target }}" == "omnibus" ]]; then
+          export ADDITIONAL_IMAGE_TAGS="${{ env.VERSION_TAG }} latest"
+        fi
+
         echo "running scripts/ci/publish.sh"
         ./scripts/ci/publish.sh
-      if: github.event_name == 'release'
+      if: github.event_name == 'workflow_dispatch'

--- a/scripts/ci/publish.sh
+++ b/scripts/ci/publish.sh
@@ -43,14 +43,6 @@ if [[ "${IMAGE_TAG:0:1}" == "v" ]]; then
   IMAGE_TAG="${IMAGE_TAG:1}"
 fi
 
-if echo "$IMAGE_TAG" | grep 'omnibus$'; then
-  if [ "$TAG_OR_HEAD" == "tags" ]; then # a release
-    ADDITIONAL_IMAGE_TAG="latest"
-  elif [ "$TAG_OR_HEAD" == "heads" ] && [ "$BRANCH_OR_TAG_NAME" == "$DEFAULT_BRANCH" ]; then # merge to default branch
-    IMAGE_TAG="dev"
-  fi
-fi
-
 ###
 # DOCKER Build & Publish
 ###
@@ -61,10 +53,10 @@ docker build -t ${REGISTRY_URL}:${IMAGE_TAG} .
 echo -e "\033[32mPushing the docker image \033[1m${REGISTRY_URL}:${IMAGE_TAG}\033[0m\033[32m to the repository...\033[0m"
 docker push ${REGISTRY_URL}:${IMAGE_TAG}
 
-if [ -n "$ADDITIONAL_IMAGE_TAG" ]; then
+for ADDITIONAL_IMAGE_TAG in ${ADDITIONAL_IMAGE_TAGS}; do
   echo -e "\033[32mAdding the additional docker tag \033[1m${REGISTRY_URL}:${ADDITIONAL_IMAGE_TAG}\033[0m"
   docker tag ${REGISTRY_URL}:${IMAGE_TAG} ${REGISTRY_URL}:${ADDITIONAL_IMAGE_TAG}
 
   echo -e "\033[32mPushing the additional docker image \033[1m${REGISTRY_URL}:${ADDITIONAL_IMAGE_TAG}\033[0m\033[32m to the repository...\033[0m"
   docker push ${REGISTRY_URL}:${ADDITIONAL_IMAGE_TAG}
-fi
+done


### PR DESCRIPTION
Looks like the prebuilt images are not built on release event, missing the publish for omnibus and other pre-defined images.
Manual workflow dispatch failed too:
https://github.com/bitovi/bitops/runs/8017291114?check_suite_focus=true#step:8:27

This PR should fix it quickly. An intermediate step to get the prebuilt images out manually via workflow dispatch, before another iteration with CD refactoring based on https://github.com/bitovi/bitops/pull/285#discussion_r952765340 discussion.