### PR TITLE
Reformat python code with black

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up latest Python
+      - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
           python-version: "3.8"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,9 @@
 name: CI
 
 on:
-  - push
-  - pull_request
+  push:
+    branches: [master]
+  pull_request:
 
 jobs:
   # Lint checks which don't depend on any service containes, etc. to be running.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  # Lint checks which don't depend on any service containes, etc. to be running.
+  lint-checks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up latest Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+          cache: 'pip'
+
+      - name: Cache Python Dependencies and Env
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/pip
+            .tox
+          key: ${{ runner.os }}-v1-python-3.8-${{ hashFiles('requirements.txt', 'test-requirements.txt', 'pyproject.toml', 'tox.ini') }}
+
+      - name: Install Python test dependencies
+        run: python -m pip install tox
+
+      - name: Run black formatting
+        run: |
+          tox -e black

--- a/.gitignore
+++ b/.gitignore
@@ -4,14 +4,106 @@
 *.gz
 *.logs
 
-# Python
-*.pyc
-
 # Security
 credentials
 .pem
 .key
 
-# Employee
-NOTES.md
-prebuild.sh
+# Python-optimized config
+#
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# mkdocs documentation
+/site
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ---------------------
 
 [![LICENSE](https://img.shields.io/badge/license-MIT-green)](LICENSE.md)
+![Python 3.8](https://img.shields.io/badge/python-3.8-blue)
 [![Latest Release](https://img.shields.io/github/v/release/bitovi/bitops)](https://github.com/bitovi/bitops/releases)
 [![GitHub Discussions](https://img.shields.io/github/discussions/bitovi/bitops)](https://github.com/bitovi/bitops/discussions)
 [![Join our Slack](https://img.shields.io/badge/slack-join%20chat-611f69.svg)](https://www.bitovi.com/community/slack?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![Python 3.8](https://img.shields.io/badge/python-3.8-blue)
 [![Latest Release](https://img.shields.io/github/v/release/bitovi/bitops)](https://github.com/bitovi/bitops/releases)
 [![GitHub Discussions](https://img.shields.io/github/discussions/bitovi/bitops)](https://github.com/bitovi/bitops/discussions)
-[![Join our Slack](https://img.shields.io/badge/slack-join%20chat-611f69.svg)](https://www.bitovi.com/community/slack?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join our Slack](https://img.shields.io/badge/slack-join%20chat-611f69.svg?logo=slack)](https://www.bitovi.com/community/slack?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ### tl;dr
 BitOps is an automated [orchestrator](docs/about.md) for deployment tools using [GitOps](https://about.gitlab.com/topics/gitops/).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ---------------------
 
+[![Build Status](https://github.com/bitovi/bitops/actions/workflows/ci.yaml/badge.svg)](https://github.com/bitovi/bitops/actions/workflows/ci.yaml)
 [![LICENSE](https://img.shields.io/badge/license-MIT-green)](LICENSE.md)
 ![Python 3.8](https://img.shields.io/badge/python-3.8-blue)
 [![Latest Release](https://img.shields.io/github/v/release/bitovi/bitops)](https://github.com/bitovi/bitops/releases)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -26,15 +26,5 @@ In most cases, you can add this signoff to your commit automatically with the
 `-s` flag to `git commit`. You must use your real name and a reachable email
 address (sorry, no pseudonyms or anonymous contributions).
 
-
 ## Code reviews
 All submissions, including submissions by project members, require review. We use GitHub pull requests for this purpose.
-
-
-## Coding Conventions
-|   |   |
-|---|---|
-| Indents  | 2 spaces (Soft)  |
-| Spaces after list items  | ["item1", "item2", "item3"]  |
-| variable naming  | snake_case  |
-

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -125,6 +125,12 @@ If you're unable to solve the merge conflicts, don't worry you'll still be able 
 
 Give your PR a meaningful title and provide details about the change in the description, including a link to the issue(s) relating to your PR. All that's left is to click the 'Create pull request' button and wait for our eager review of your code!
 
+### Python Style guide
+* Use 4 spaces for a tab.
+* We use [`black` code formatter](https://github.com/psf/black) which automatically enforces consistent style on the whole code base.
+* You can verify that your modifications don’t break any rules by running the lint script - `tox -e black`.
+* You can autoformat the python code by running `black` manually or by configuring your favorite editor to do it for you. [Here](https://dev.to/adamlombard/how-to-use-the-black-python-code-formatter-in-vscode-3lo0) is an example for VSCode.
+
 ### Bash Style guide
 
 The BitOps container uses the Bourne shell during execution, please ensure all functions used in your submission exist for `sh`. Submissions that utilize alternate shells (`zsh`,`ksh`,`csh`, etc.) will not be accepted.

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -138,7 +138,7 @@ The BitOps container uses the Bourne shell during execution, please ensure all f
 BitOps comes packaged with [`shyaml`](https://pypi.org/project/shyaml/) which can be used to parse YAML config files from stdout.
 
 When contributing Bash code segments to BitOps please keep these concepts in mind:
-
+* Use 2 spaces for a tab.
 * Add `echo` statements during plugin execution to give verbosity and debugging during execution
 * Update any related documentation to the code or feature you are modifying
 * Avoid multiple commands per line if possible. Replace `;` with whitespace and newline characters where appropriate.

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -126,6 +126,7 @@ If you're unable to solve the merge conflicts, don't worry you'll still be able 
 Give your PR a meaningful title and provide details about the change in the description, including a link to the issue(s) relating to your PR. All that's left is to click the 'Create pull request' button and wait for our eager review of your code!
 
 ### Python Style guide
+
 * Use 4 spaces for a tab.
 * We use [`black` code formatter](https://github.com/psf/black) which automatically enforces consistent style on the whole code base.
 * You can verify that your modifications don’t break any rules by running the lint script - `tox -e black`.
@@ -138,6 +139,7 @@ The BitOps container uses the Bourne shell during execution, please ensure all f
 BitOps comes packaged with [`shyaml`](https://pypi.org/project/shyaml/) which can be used to parse YAML config files from stdout.
 
 When contributing Bash code segments to BitOps please keep these concepts in mind:
+
 * Use 2 spaces for a tab.
 * Add `echo` statements during plugin execution to give verbosity and debugging during execution
 * Update any related documentation to the code or feature you are modifying

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ hide:
         <a class="md-button md-button--primary" href="getting-started">Show me how</a>
         <p>
             <a href="license/"><img alt="LICENSE" src="https://img.shields.io/badge/license-MIT-green"></a>
+            <img alt="Python 3.8" src="https://img.shields.io/badge/python-3.8-blue">
             <a href="https://github.com/bitovi/bitops/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/bitovi/bitops"></a>
             <a href="https://github.com/bitovi/bitops/discussions"><img alt="BitOps Discussions" src="https://img.shields.io/github/discussions/bitovi/bitops"></a>
             <a href="https://www.bitovi.com/community/slack?utm_source=badge&amp;utm_medium=badge&amp;utm_campaign=pr-badge&amp;utm_content=badge"><img alt="Join our Slack" src="https://img.shields.io/badge/slack-join%20chat-611f69.svg"></a>

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ hide:
             <img alt="Python 3.8" src="https://img.shields.io/badge/python-3.8-blue">
             <a href="https://github.com/bitovi/bitops/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/bitovi/bitops"></a>
             <a href="https://github.com/bitovi/bitops/discussions"><img alt="BitOps Discussions" src="https://img.shields.io/github/discussions/bitovi/bitops"></a>
-            <a href="https://www.bitovi.com/community/slack?utm_source=badge&amp;utm_medium=badge&amp;utm_campaign=pr-badge&amp;utm_content=badge"><img alt="Join our Slack" src="https://img.shields.io/badge/slack-join%20chat-611f69.svg"></a>
+            <a href="https://www.bitovi.com/community/slack?utm_source=badge&amp;utm_medium=badge&amp;utm_campaign=pr-badge&amp;utm_content=badge"><img alt="Join our Slack" src="https://img.shields.io/badge/slack-join%20chat-611f69.svg?logo=slack"></a>
             <a class="github-button" href="https://github.com/bitovi/bitops" data-icon="octicon-star" data-show-count="true" aria-label="Star BitOps on GitHub">Star</a>
         </p>
     </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+# Black code formatter configuration
+# https://black.readthedocs.io/en/stable/
+[tool.black]
+target_version = ['py38']
+include = '\.pyi?$'
+color = true

--- a/scripts/plugins.py
+++ b/scripts/plugins.py
@@ -16,16 +16,17 @@ if __name__ == "__main__":
         mode = None
 
     bitops_figlet = pyfiglet.figlet_format("BitOps")
-    bitops_description = \
-    """
+    bitops_description = """
     BitOps is a way to describe the infrastructure and things deployed onto that infrastructure for multiple environments in a single place called an Operations Repo.
     """
-    logger.info("\n\n{figlet}{description}"
-        .format(
-            figlet=bitops_figlet,
-            description=bitops_description))
-    
-    logger.info("\n\n\n#~#~#~#~ BITOPS CONFIGURATION ~#~#~#~    \
+    logger.info(
+        "\n\n{figlet}{description}".format(
+            figlet=bitops_figlet, description=bitops_description
+        )
+    )
+
+    logger.info(
+        "\n\n\n#~#~#~#~ BITOPS CONFIGURATION ~#~#~#~    \
     \n\tFAIL FAST:              [{fail_fast}]                   \
     \n\tRUN MODE:               [{run_mode}]                    \
     \n\tDEFAULT RUN MODE:       [{mode}]                        \
@@ -35,14 +36,15 @@ if __name__ == "__main__":
     \n\tBITOPS CONFIG FILE:     [{config_file}]                 \
     \n#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#\n                   \
     ".format(
-        fail_fast=plugins.settings.BITOPS_fast_fail_mode, 
-        run_mode=plugins.settings.BITOPS_run_mode, 
-        mode=mode,
-        log_level=plugins.settings.BITOPS_logging_level,
-        log_color=plugins.settings.BITOPS_logging_color,
-        config_file=plugins.settings.BITOPS_config_file
-    ))
-    
+            fail_fast=plugins.settings.BITOPS_fast_fail_mode,
+            run_mode=plugins.settings.BITOPS_run_mode,
+            mode=mode,
+            log_level=plugins.settings.BITOPS_logging_level,
+            log_color=plugins.settings.BITOPS_logging_color,
+            config_file=plugins.settings.BITOPS_config_file,
+        )
+    )
+
     if mode == "deploy":
         Deploy_Plugins()
     elif mode == "install":
@@ -56,4 +58,3 @@ if __name__ == "__main__":
         exit(0)
     else:
         print("Mode is not specified. Please use [plugins.py install|deploy]")
-

--- a/scripts/plugins/__init__.py
+++ b/scripts/plugins/__init__.py
@@ -1,2 +1,3 @@
 import logging
+
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/scripts/plugins/deploy_plugins.py
+++ b/scripts/plugins/deploy_plugins.py
@@ -10,24 +10,36 @@ from pickle import GLOBAL
 from shutil import rmtree
 from distutils.dir_util import copy_tree
 from .utilities import Get_Config_List, Handle_Hooks
-from .settings import BITOPS_config_yaml, BITOPS_fast_fail_mode, BITOPS_config_yaml, bitops_build_configuration, BITOPS_ENV_environment, BITOPS_default_folder, BITOPS_timeout
+from .settings import (
+    BITOPS_config_yaml,
+    BITOPS_fast_fail_mode,
+    BITOPS_config_yaml,
+    bitops_build_configuration,
+    BITOPS_ENV_environment,
+    BITOPS_default_folder,
+    BITOPS_timeout,
+)
 from .logging import logger
 from munch import DefaultMunch
 
 
 def Deploy_Plugins():
-    #~#~#~#~#~#~# STAGE 1 - ENVIRONMENT LOADING #~#~#~#~#~#~#
+    # ~#~#~#~#~#~# STAGE 1 - ENVIRONMENT LOADING #~#~#~#~#~#~#
     # Temp directory setup
     temp_dir = tempfile.mkdtemp()
-    bitops_deployment_configuration = DefaultMunch.fromDict(bitops_build_configuration.bitops.deployments, None)
+    bitops_deployment_configuration = DefaultMunch.fromDict(
+        bitops_build_configuration.bitops.deployments, None
+    )
 
     bitops_dir = "/opt/bitops"
     bitops_deployment_dir = "/opt/bitops_deployment/"
-    bitops_plugins_dir = bitops_dir + '/scripts/plugins/'
+    bitops_plugins_dir = bitops_dir + "/scripts/plugins/"
 
     bitops_root_dir = temp_dir
 
-    bitops_envroot_dir = "{}/{}".format(bitops_root_dir, BITOPS_ENV_environment) # What is the difference between this and bitops_operations_dir ...
+    bitops_envroot_dir = "{}/{}".format(
+        bitops_root_dir, BITOPS_ENV_environment
+    )  # What is the difference between this and bitops_operations_dir ...
     bitops_default_envroot = "{}/{}".format(bitops_root_dir, BITOPS_default_folder)
     bitops_operations_dir = "{}/{}".format(temp_dir, BITOPS_ENV_environment)
     bitops_scripts_dir = "{}/scripts".format(bitops_dir)
@@ -35,9 +47,7 @@ def Deploy_Plugins():
     PATH = os.environ.get("PATH")
     PATH += ":/root/.local/bin"
 
-
     # Cleanup - Call all teardown scripts - TODO
-
 
     # Set global variables
     os.environ["BITOPS_TEMPDIR"] = temp_dir
@@ -52,7 +62,7 @@ def Deploy_Plugins():
 
     # Global environment evaluation
     # TODO: Drop support for 'ENVIRONMENT' env var
-    if 'ENVIRONMENT' in os.environ:
+    if "ENVIRONMENT" in os.environ:
         logger.warning(
             "'ENVIRONMENT' var is deprecated in v2.0.0 and will be removed in the future versions! "
             "Use the 'BITOPS_ENVIRONMENT' env var instead!"
@@ -67,16 +77,18 @@ def Deploy_Plugins():
 
     # Move to temp directory
     if not os.path.isdir(bitops_deployment_dir):
-        logger.error("An operations repo needs to be mounted to the Docker container with the path `/opt/bitops_deployment/`... Exiting.\n\t\tFor more information on this issue please checkout our doc [https://bitovi.github.io/bitops/about/#how-bitops-works]")
+        logger.error(
+            "An operations repo needs to be mounted to the Docker container with the path `/opt/bitops_deployment/`... Exiting.\n\t\tFor more information on this issue please checkout our doc [https://bitovi.github.io/bitops/about/#how-bitops-works]"
+        )
         quit(1)
     copy_tree(bitops_deployment_dir, temp_dir)
-
 
     if bitops_deployment_configuration is None:
         logger.error("No deployments config found. Exiting... {}".format(__file__))
         quit(1)
-        
-    logger.info("\n\n\n~#~#~#~BITOPS DEPLOYMENT CONFIGURATION~#~#~#~            \
+
+    logger.info(
+        "\n\n\n~#~#~#~BITOPS DEPLOYMENT CONFIGURATION~#~#~#~            \
             \n\t TEMP_DIR:                [{temp_dir}]                          \
             \n\t DEFAULT_FOLDER_NAME:     [{default_folder_name}]               \
             \n\t BITOPS_ENVIRONMENT:      [{env}]                               \
@@ -89,173 +101,228 @@ def Deploy_Plugins():
             \n\t BITOPS_OPERATIONS_DIR:   [{bitops_operations_dir}]             \
             \n\t BITOPS_SCRIPTS_DIR:      [{bitops_scripts_dir}]                \
             \n#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~# \n                        \
-            ".format(                                                       
-                temp_dir=temp_dir,
-                default_folder_name=BITOPS_default_folder,
-                env=BITOPS_ENV_environment,
-                timeout=BITOPS_timeout,
-                
-                bitops_dir=bitops_dir,
-                bitops_deployment_dir=bitops_deployment_dir,
-                bitops_plugin_dir=bitops_plugins_dir,
-                bitops_envroot_dir=bitops_envroot_dir,
-                bitops_operations_dir=bitops_operations_dir,
-                bitops_scripts_dir=bitops_scripts_dir,
-            ))
+            ".format(
+            temp_dir=temp_dir,
+            default_folder_name=BITOPS_default_folder,
+            env=BITOPS_ENV_environment,
+            timeout=BITOPS_timeout,
+            bitops_dir=bitops_dir,
+            bitops_deployment_dir=bitops_deployment_dir,
+            bitops_plugin_dir=bitops_plugins_dir,
+            bitops_envroot_dir=bitops_envroot_dir,
+            bitops_operations_dir=bitops_operations_dir,
+            bitops_scripts_dir=bitops_scripts_dir,
+        )
+    )
     # Loop through deployments and invoke each
-    #~#~#~#~#~#~# STAGE 2 - PLUGIN LOADING #~#~#~#~#~#~#
+    # ~#~#~#~#~#~# STAGE 2 - PLUGIN LOADING #~#~#~#~#~#~#
     for deployment in bitops_deployment_configuration:
-        logger.info("\n\n\n~#~#~#~PROCESSING STAGE [{}]~#~#~#~\n".format(deployment.upper()))
+        logger.info(
+            "\n\n\n~#~#~#~PROCESSING STAGE [{}]~#~#~#~\n".format(deployment.upper())
+        )
         plugin_name = bitops_deployment_configuration[deployment].plugin
 
         # Set plugin vars
-        plugin_dir = bitops_plugins_dir + plugin_name                           # Sourced from BitOps Core + plugin install
-        opsrepo_environment_dir = bitops_operations_dir + '/' + deployment      # Sourced from Operations repo
-        os.environ['BITOPS_PLUGIN_DIR'] = plugin_dir
-        os.environ['BITOPS_OPSREPO_ENVIRONMENT_DIR'] = opsrepo_environment_dir
+        plugin_dir = (
+            bitops_plugins_dir + plugin_name
+        )  # Sourced from BitOps Core + plugin install
+        opsrepo_environment_dir = (
+            bitops_operations_dir + "/" + deployment
+        )  # Sourced from Operations repo
+        os.environ["BITOPS_PLUGIN_DIR"] = plugin_dir
+        os.environ["BITOPS_OPSREPO_ENVIRONMENT_DIR"] = opsrepo_environment_dir
         if os.path.isdir(opsrepo_environment_dir):
             # Reconcile BitOps config using existing shell scripts
-            opsrepo_env_file = opsrepo_environment_dir + '/' + 'ENV_FILE'
-            os.environ['BITOPS_OPSREPO_ENV_FILE'] = opsrepo_env_file
+            opsrepo_env_file = opsrepo_environment_dir + "/" + "ENV_FILE"
+            os.environ["BITOPS_OPSREPO_ENV_FILE"] = opsrepo_env_file
 
-            opsrepo_config_file = opsrepo_environment_dir + '/' + 'bitops.config.yaml'
-            plugin_schema_file = plugin_dir+"/bitops.schema.yaml"
-            
-            logger.info("\n\n\n~#~#~#~{deployment} DEPLOYMENT CONFIGURATION~#~#~#~  \
+            opsrepo_config_file = opsrepo_environment_dir + "/" + "bitops.config.yaml"
+            plugin_schema_file = plugin_dir + "/bitops.schema.yaml"
+
+            logger.info(
+                "\n\n\n~#~#~#~{deployment} DEPLOYMENT CONFIGURATION~#~#~#~  \
             \n\t PLUGIN_DIR:            [{plugin_dir}]                      \
             \n\t ENVIRONMENT_DIR:       [{opsrepo_environment_dir}]         \
             \n\t ENVIRONMENT_FILE_PATH: [{opsrepo_env_file}]                \
             \n\t CONFIG_FILE_PATH:      [{opsrepo_config_file_path}]        \
             \n#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~# \n                    \
-            ".format(                                                       
-                deployment=deployment.upper(),                                      
-                plugin_dir=plugin_dir,
-                opsrepo_environment_dir=opsrepo_environment_dir,
-                opsrepo_env_file=opsrepo_env_file,
-                opsrepo_config_file_path=opsrepo_config_file,
-            ))
+            ".format(
+                    deployment=deployment.upper(),
+                    plugin_dir=plugin_dir,
+                    opsrepo_environment_dir=opsrepo_environment_dir,
+                    opsrepo_env_file=opsrepo_env_file,
+                    opsrepo_config_file_path=opsrepo_config_file,
+                )
+            )
             logger.info("loading config file: [{}]".format(opsrepo_config_file))
             logger.debug("loading ENV_FILE   : [{}]".format(opsrepo_env_file))
 
-            # logic related to plugin.config.yaml 
-            plugin_configuration_path = plugin_dir+'/plugin.config.yaml'
+            # logic related to plugin.config.yaml
+            plugin_configuration_path = plugin_dir + "/plugin.config.yaml"
             try:
-                with open(plugin_configuration_path, 'r') as stream:
-                    plugin_configuration_yaml = yaml.load(stream, Loader=yaml.FullLoader)
+                with open(plugin_configuration_path, "r") as stream:
+                    plugin_configuration_yaml = yaml.load(
+                        stream, Loader=yaml.FullLoader
+                    )
 
             except FileNotFoundError as e:
-                logger.warning("No plugin file was found at path: [{}]".format(plugin_configuration_path))
-                plugin_configuration_yaml = {"plugin" : {"deployment": {}}}
+                logger.warning(
+                    "No plugin file was found at path: [{}]".format(
+                        plugin_configuration_path
+                    )
+                )
+                plugin_configuration_yaml = {"plugin": {"deployment": {}}}
 
             # plugin.config.yaml
-            plugin_configuration = \
-                None if plugin_configuration_yaml is None \
-                else DefaultMunch.fromDict(plugin_configuration_yaml, None)   
+            plugin_configuration = (
+                None
+                if plugin_configuration_yaml is None
+                else DefaultMunch.fromDict(plugin_configuration_yaml, None)
+            )
 
             # plugin.deployment.deployment_script
-            plugin_deploy_script = plugin_configuration.plugin.deployment.deployment_script  \
-                if plugin_configuration.plugin.deployment.deployment_script is not None       \
+            plugin_deploy_script = (
+                plugin_configuration.plugin.deployment.deployment_script
+                if plugin_configuration.plugin.deployment.deployment_script is not None
                 else "deploy.sh"
+            )
 
             # plugin.deployment.language
-            plugin_deploy_language = plugin_configuration.plugin.deployment.language  \
-                if plugin_configuration.plugin.deployment.language is not None       \
+            plugin_deploy_language = (
+                plugin_configuration.plugin.deployment.language
+                if plugin_configuration.plugin.deployment.language is not None
                 else "bash"
+            )
 
-            plugin_deploy_script_path = plugin_dir+"/{}".format(plugin_deploy_script)
+            plugin_deploy_script_path = plugin_dir + "/{}".format(plugin_deploy_script)
 
             # plugin.deployment.schema_parsing
-            plugin_deploy_schema_parsing_flag = plugin_configuration.plugin.deployment.core_schema_parsing \
-                if plugin_configuration.plugin.deployment.core_schema_parsing is not None \
+            plugin_deploy_schema_parsing_flag = (
+                plugin_configuration.plugin.deployment.core_schema_parsing
+                if plugin_configuration.plugin.deployment.core_schema_parsing
+                is not None
                 else "true"
-            
+            )
+
             # plugin.deployment.before_hook_scripts
-            plugin_deploy_before_hook_scripts_flag = plugin_configuration.plugin.deployment.before_hook_scripts \
-                if plugin_configuration.plugin.deployment.before_hook_scripts is not None \
+            plugin_deploy_before_hook_scripts_flag = (
+                plugin_configuration.plugin.deployment.before_hook_scripts
+                if plugin_configuration.plugin.deployment.before_hook_scripts
+                is not None
                 else "true"
+            )
 
             # plugin.deployment.after_hook_scripts
-            plugin_deploy_after_hook_scripts_flag = plugin_configuration.plugin.deployment.after_hook_scripts \
-                if plugin_configuration.plugin.deployment.after_hook_scripts is not None \
+            plugin_deploy_after_hook_scripts_flag = (
+                plugin_configuration.plugin.deployment.after_hook_scripts
+                if plugin_configuration.plugin.deployment.after_hook_scripts is not None
                 else "true"
-            
+            )
+
             # Check if deploy script is present
             if os.path.isfile(plugin_deploy_script_path):
                 if plugin_deploy_schema_parsing_flag:
                     logger.debug("running bitops schema parsing...")
-                    cli_config_list, options_config_list = Get_Config_List(opsrepo_config_file, plugin_schema_file)
+                    cli_config_list, options_config_list = Get_Config_List(
+                        opsrepo_config_file, plugin_schema_file
+                    )
 
-                    stack_action=""
+                    stack_action = ""
                     for item in cli_config_list:
-                        if item.name == "stack-action": 
+                        if item.name == "stack-action":
                             stack_action = item.value
                             break
                 else:
-                    logger.warning("setting null value for stack_action...." )
+                    logger.warning("setting null value for stack_action....")
                     stack_action = ""
 
                 # Adding print env logging
                 bitops_env_vars = [item for item in os.environ if "BITOPS_" in item]
                 bitops_env_vars.sort()
-                env_vars_msg="\n\n~#~#~#~BITOPS ENVIRONMENT VARIABLES~#~#~#~"
+                env_vars_msg = "\n\n~#~#~#~BITOPS ENVIRONMENT VARIABLES~#~#~#~"
                 for item in bitops_env_vars:
-                    value=os.environ.get(item)
-                    env_vars_msg+="\n\t{}={}".format(item, value)
+                    value = os.environ.get(item)
+                    env_vars_msg += "\n\t{}={}".format(item, value)
                 logger.debug(env_vars_msg)
 
-                #~#~#~#~#~#~# STAGE 3 - BEFORE HOOKS #~#~#~#~#~#~#
+                # ~#~#~#~#~#~# STAGE 3 - BEFORE HOOKS #~#~#~#~#~#~#
                 # Summary
                 #   The reason the before hooks have been placed here is because I'd like to ensure that the plugin level environment loading has been completed. This will ensure the before hook have access to all the same environment variables as the deployment invoking stage does.
 
                 # Check whether a plugin is using the before hook
                 if plugin_deploy_before_hook_scripts_flag:
-                    hooks_folder = opsrepo_environment_dir+"/bitops.before-deploy.d"
+                    hooks_folder = opsrepo_environment_dir + "/bitops.before-deploy.d"
                     Handle_Hooks("before", hooks_folder)
 
                 else:
                     logger.warning("BitOps Core isn't invoking before hooks")
 
-                
-                #~#~#~#~#~#~# STAGE 4 - PLUGIN DEPLOYMENT INVOKE #~#~#~#~#~#~#
+                # ~#~#~#~#~#~# STAGE 4 - PLUGIN DEPLOYMENT INVOKE #~#~#~#~#~#~#
                 # Add executable flag to deploy.sh
                 os.chmod(plugin_deploy_script_path, 775)
-                logger.info("\n\t\tRUNNING DEPLOYMENT SCRIPT    \
+                logger.info(
+                    "\n\t\tRUNNING DEPLOYMENT SCRIPT    \
                                 \n\t\t\tLANGUAGE:       [{}]    \
                                 \n\t\t\tSCRIPT PATH:    [{}]    \
-                                \n\t\t\tSTACK ACTION:   [{}]".format(plugin_deploy_language, plugin_deploy_script_path, stack_action))
-                
+                                \n\t\t\tSTACK ACTION:   [{}]".format(
+                        plugin_deploy_language, plugin_deploy_script_path, stack_action
+                    )
+                )
+
                 try:
-                    result = subprocess.run([plugin_deploy_language, plugin_deploy_script_path, stack_action], 
-                        universal_newlines = True,
-                        capture_output=True)
-                
+                    result = subprocess.run(
+                        [
+                            plugin_deploy_language,
+                            plugin_deploy_script_path,
+                            stack_action,
+                        ],
+                        universal_newlines=True,
+                        capture_output=True,
+                    )
+
                 except Exception as exc:
                     logger.error(exc)
-                    if BITOPS_fast_fail_mode: quit(101)
-                    
+                    if BITOPS_fast_fail_mode:
+                        quit(101)
+
                 if result.returncode == 0:
-                    logger.info("\n~#~#~#~DEPLOYING OPS REPO [{deployment}] SUCCESSFULLY COMPLETED~#~#~#~".format(deployment=deployment))
+                    logger.info(
+                        "\n~#~#~#~DEPLOYING OPS REPO [{deployment}] SUCCESSFULLY COMPLETED~#~#~#~".format(
+                            deployment=deployment
+                        )
+                    )
                     logger.debug(result.stdout)
                     # TODO: DEEP DEBUG
-                    #logger.debug("\n\tSTDERR: [{stderr}]\n\tRESULTS: [{result}]".format(stdout=result.stdout, stderr=result.stderr, result=result))
+                    # logger.debug("\n\tSTDERR: [{stderr}]\n\tRESULTS: [{result}]".format(stdout=result.stdout, stderr=result.stderr, result=result))
                 else:
-                    logger.warning("\n~#~#~#~DEPLOYING OPS REPO [{deployment}] FAILED~#~#~#~".format(deployment=deployment))
+                    logger.warning(
+                        "\n~#~#~#~DEPLOYING OPS REPO [{deployment}] FAILED~#~#~#~".format(
+                            deployment=deployment
+                        )
+                    )
                     logger.debug(result.stdout)
                     logger.error(result.stderr)
                     # TODO: DEEP DEBUG
-                    #logger.debug("\n\tSTDOUT:[{stdout}]\n\tSTDERR: [{stderr}]\n\tRESULTS: [{result}]".format(stdout=result.stdout, stderr=result.stderr, result=result))
-            
-                #~#~#~#~#~#~# STAGE 5 - AFTER HOOKS #~#~#~#~#~#~#
+                    # logger.debug("\n\tSTDOUT:[{stdout}]\n\tSTDERR: [{stderr}]\n\tRESULTS: [{result}]".format(stdout=result.stdout, stderr=result.stderr, result=result))
+
+                # ~#~#~#~#~#~# STAGE 5 - AFTER HOOKS #~#~#~#~#~#~#
                 if plugin_deploy_after_hook_scripts_flag:
-                    hooks_folder = opsrepo_environment_dir+"/bitops.after-deploy.d"
+                    hooks_folder = opsrepo_environment_dir + "/bitops.after-deploy.d"
                     Handle_Hooks("after", hooks_folder)
 
                 else:
                     logger.warning("BitOps Core isn't invoking after hooks")
-            
-            
+
             else:
-                logger.error("Plugin deploy script missing. Exiting[{plugin_deploy_language}]".format(plugin_deploy_script_path))
+                logger.error(
+                    "Plugin deploy script missing. Exiting[{plugin_deploy_language}]".format(
+                        plugin_deploy_script_path
+                    )
+                )
                 quit(1)
         else:
-            logger.warning("Opsrepo environment directory does not exist: [{}]".format(opsrepo_environment_dir))
+            logger.warning(
+                "Opsrepo environment directory does not exist: [{}]".format(
+                    opsrepo_environment_dir
+                )
+            )

--- a/scripts/plugins/doc.py
+++ b/scripts/plugins/doc.py
@@ -5,9 +5,12 @@ import json
 fh = open("scripts/plugins/documentation.json")
 jh = json.load(fh)
 
+
 def Get_Doc(lookup_key):
     try:
-        msg = "\n\t{}\n\tFor more information checkout the Bitops Documentation: [{}]".format(jh[lookup_key]["msg"], jh[lookup_key]["link"])
+        msg = "\n\t{}\n\tFor more information checkout the Bitops Documentation: [{}]".format(
+            jh[lookup_key]["msg"], jh[lookup_key]["link"]
+        )
     except KeyError:
         return "DEVELOPER NOTE: Check lookup code and confirm that it is in the documentation config. Something has gone wrong."
     return msg

--- a/scripts/plugins/install_plugins.py
+++ b/scripts/plugins/install_plugins.py
@@ -18,89 +18,126 @@ from munch import DefaultMunch, Munch
 
 def Install_Plugins():
     bitops_build_configuration = DefaultMunch.fromDict(BITOPS_config_yaml, None)
-    bitops_plugins_configuration = DefaultMunch.fromDict(bitops_build_configuration.bitops.plugins, None)
+    bitops_plugins_configuration = DefaultMunch.fromDict(
+        bitops_build_configuration.bitops.plugins, None
+    )
 
     plugin_dir = BITOPS_plugin_dir
     plugin_list = [item for item in bitops_plugins_configuration]
     # Loop through plugins and clone
     for plugin_config in bitops_plugins_configuration:
-        logger.info("\n\n\n~#~#~#~PROCESSING STAGE [{}]~#~#~#~\n".format(plugin_config.upper()))
+        logger.info(
+            "\n\n\n~#~#~#~PROCESSING STAGE [{}]~#~#~#~\n".format(plugin_config.upper())
+        )
         # for plugin in bitops_plugins_configuration[plugin_config]:
-        
+
         plugin_source = bitops_plugins_configuration[plugin_config].source
-        
+
         logger.info("\n\n\n~#~#~#~PLUGIN SOURCE [{}]~#~#~#~\n".format(plugin_source))
 
         if plugin_source is not None:
-            #~#~#~#~#~#~#~#~#~#~#~#~#~#
+            # ~#~#~#~#~#~#~#~#~#~#~#~#~#
             # CLONE PLUGIN FROM SOURCE
-            #~#~#~#~#~#~#~#~#~#~#~#~#~#
+            # ~#~#~#~#~#~#~#~#~#~#~#~#~#
 
-            plugin_tag = bitops_plugins_configuration[plugin_config].source_tag if bitops_plugins_configuration[plugin_config].source_tag is not None else "latest"
-            plugin_branch = bitops_plugins_configuration[plugin_config].source_branch if bitops_plugins_configuration[plugin_config].source_branch is not None else "main"
-            
+            plugin_tag = (
+                bitops_plugins_configuration[plugin_config].source_tag
+                if bitops_plugins_configuration[plugin_config].source_tag is not None
+                else "latest"
+            )
+            plugin_branch = (
+                bitops_plugins_configuration[plugin_config].source_branch
+                if bitops_plugins_configuration[plugin_config].source_branch is not None
+                else "main"
+            )
 
-            logger.info("\n\n\n~#~#~#~CLONING PLUGIN [{plugin_config}]~#~#~#~  \
+            logger.info(
+                "\n\n\n~#~#~#~CLONING PLUGIN [{plugin_config}]~#~#~#~  \
             \n\t PLUGIN_SOURCE:         [{plugin_source}]               \
             \n\t PLUGIN_TAG:            [{plugin_tag}]                  \
             \n\t PLUGIN_BRANCH:         [{plugin_branch}]                \
             \n#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~# \n                \
-            ".format(                                                 
-                plugin_config=plugin_config.upper(),
-                plugin_source=plugin_source,
-                plugin_tag=plugin_tag,
-                plugin_branch=plugin_branch
-            ))
+            ".format(
+                    plugin_config=plugin_config.upper(),
+                    plugin_source=plugin_source,
+                    plugin_tag=plugin_tag,
+                    plugin_branch=plugin_branch,
+                )
+            )
 
             try:
                 # Non-Entry default
                 if plugin_branch == "latest" and plugin_tag == "main":
-                    git.Repo.clone_from(plugin_source, plugin_dir+plugin_config)
+                    git.Repo.clone_from(plugin_source, plugin_dir + plugin_config)
 
                 # If the plugin branch and tag are specified, default to branch
                 elif plugin_branch is not None and plugin_tag is not None:
-                    git.Repo.clone_from(plugin_source, plugin_dir+plugin_config, branch=plugin_branch)
+                    git.Repo.clone_from(
+                        plugin_source, plugin_dir + plugin_config, branch=plugin_branch
+                    )
 
                 else:
-                    plugin_pull_branch = plugin_tag if plugin_branch is None else plugin_branch
-                    git.Repo.clone_from(plugin_source, plugin_dir+plugin_config, branch=plugin_pull_branch)
-                
-                logger.info("\n~#~#~#~CLONING PLUGIN [{plugin_config}] SUCCESSFULLY COMPLETED~#~#~#~".format(plugin_config=plugin_config))
+                    plugin_pull_branch = (
+                        plugin_tag if plugin_branch is None else plugin_branch
+                    )
+                    git.Repo.clone_from(
+                        plugin_source,
+                        plugin_dir + plugin_config,
+                        branch=plugin_pull_branch,
+                    )
+
+                logger.info(
+                    "\n~#~#~#~CLONING PLUGIN [{plugin_config}] SUCCESSFULLY COMPLETED~#~#~#~".format(
+                        plugin_config=plugin_config
+                    )
+                )
 
             except git.exc.GitCommandError as exc:
-                logger.error("\n~#~#~#~CLONING PLUGIN [{plugin_config}] FAILED~#~#~#~\n\t{stderr}"
-                    .format(
-                        plugin_config=plugin_config,
-                        stderr=exc
-                    ))
-                sys.exit(1)
-            
-            except Exception as exc:
-                logger.error("\n~#~#~#~CLONING PLUGIN [{plugin_config}] CRITICAL ERROR~#~#~#~\n\t{stderr}"
-                    .format(
-                        plugin_config=plugin_config,
-                        stderr=exc
-                    ))
+                logger.error(
+                    "\n~#~#~#~CLONING PLUGIN [{plugin_config}] FAILED~#~#~#~\n\t{stderr}".format(
+                        plugin_config=plugin_config, stderr=exc
+                    )
+                )
                 sys.exit(1)
 
-            #~#~#~#~#~#~#~#~#~#~#~#~#~#
+            except Exception as exc:
+                logger.error(
+                    "\n~#~#~#~CLONING PLUGIN [{plugin_config}] CRITICAL ERROR~#~#~#~\n\t{stderr}".format(
+                        plugin_config=plugin_config, stderr=exc
+                    )
+                )
+                sys.exit(1)
+
+            # ~#~#~#~#~#~#~#~#~#~#~#~#~#
             # RUN PLUGIN INSTALL SCRIPT
-            #~#~#~#~#~#~#~#~#~#~#~#~#~#
+            # ~#~#~#~#~#~#~#~#~#~#~#~#~#
 
             # Once the plugin is cloned, begin using its config + schema
-            plugin_configuration_path = plugin_dir+plugin_config+"/plugin.config.yaml" 
-            logger.info("plugin_configuration_path ==>[{}]".format(plugin_configuration_path) )
+            plugin_configuration_path = (
+                plugin_dir + plugin_config + "/plugin.config.yaml"
+            )
+            logger.info(
+                "plugin_configuration_path ==>[{}]".format(plugin_configuration_path)
+            )
             try:
-                with open(plugin_configuration_path, 'r') as stream:
-                    plugin_configuration_yaml = yaml.load(stream, Loader=yaml.FullLoader)
-            
-            except FileNotFoundError as e:
-                logger.warning("No plugin file was found at path: [{}]".format(plugin_configuration_path))
-                plugin_configuration_yaml = {"plugin" : {"install": {}}}
+                with open(plugin_configuration_path, "r") as stream:
+                    plugin_configuration_yaml = yaml.load(
+                        stream, Loader=yaml.FullLoader
+                    )
 
-            plugin_configuration = \
-                None if plugin_configuration_yaml is None \
-                else DefaultMunch.fromDict(plugin_configuration_yaml, None)                
+            except FileNotFoundError as e:
+                logger.warning(
+                    "No plugin file was found at path: [{}]".format(
+                        plugin_configuration_path
+                    )
+                )
+                plugin_configuration_yaml = {"plugin": {"install": {}}}
+
+            plugin_configuration = (
+                None
+                if plugin_configuration_yaml is None
+                else DefaultMunch.fromDict(plugin_configuration_yaml, None)
+            )
 
             # breakdown of values
             #   plugin.config.yaml should be used first
@@ -108,73 +145,108 @@ def Install_Plugins():
             #   A default value should be used as a last resort
 
             # plugin.install.install_script
-            plugin_install_script = plugin_configuration.plugin.install.install_script  \
-                if plugin_configuration.plugin.install.install_script is not None       \
+            plugin_install_script = (
+                plugin_configuration.plugin.install.install_script
+                if plugin_configuration.plugin.install.install_script is not None
                 else "install.sh"
+            )
 
             # plugin.install.language
-            plugin_install_language = plugin_configuration.plugin.install.language  \
-                if plugin_configuration.plugin.install.language is not None       \
+            plugin_install_language = (
+                plugin_configuration.plugin.install.language
+                if plugin_configuration.plugin.install.language is not None
                 else "bash"
-            
+            )
+
             # plugin.install.dependencies
-            plugin_install_dependencies = plugin_configuration.plugin.install.dependencies  \
-                if plugin_configuration.plugin.install.dependencies is not None       \
+            plugin_install_dependencies = (
+                plugin_configuration.plugin.install.dependencies
+                if plugin_configuration.plugin.install.dependencies is not None
                 else None
+            )
 
             # Checking that any dependency for a plugin is found within the bitops.config.yaml plugins section
             if plugin_install_dependencies:
-                missing_dependencies = list(set(plugin_install_dependencies).difference(plugin_list))
+                missing_dependencies = list(
+                    set(plugin_install_dependencies).difference(plugin_list)
+                )
 
                 if missing_dependencies:
-                    logger.critical("MISSING DEPENDENCY \
+                    logger.critical(
+                        "MISSING DEPENDENCY \
                     \n\t NEEDED DEPENDENCY: [{}] \
                     \n\t PLUGIN LIST:       [{}] \
                     \n\t\t {doc_link} \
                     ".format(
-                        missing_dependencies,
-                        plugin_list,
-                        doc_link=Get_Doc("missing_plugin_dependency")
-                    ))
+                            missing_dependencies,
+                            plugin_list,
+                            doc_link=Get_Doc("missing_plugin_dependency"),
+                        )
+                    )
                     exit(10)
 
-
             # install plugin dependencies (install.sh)
-            plugin_install_script_path = plugin_dir + plugin_config + "/{}".format(plugin_install_script)
-            
+            plugin_install_script_path = (
+                plugin_dir + plugin_config + "/{}".format(plugin_install_script)
+            )
 
-            logger.info("\n\n\n~#~#~#~INSTALLING PLUGIN [{plugin_config}]~#~#~#~   \
+            logger.info(
+                "\n\n\n~#~#~#~INSTALLING PLUGIN [{plugin_config}]~#~#~#~   \
             \n\t PLUGIN_INSTALL_SCRIPT:             [{plugin_install_script}]          \
             \n\t PLUGIN_INSTALL_LANGUAGE:           [{plugin_install_language}]        \
             \n\t PLUGIN_DEPENDENCIES:               [{plugin_install_dependencies}]        \
             \n\t PLUGIN_CONFIG_PATH:                [{plugin_configuration_path}]        \
             \n#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~# \n                    \
-            ".format(  
-                plugin_config=plugin_config,                                               
-                plugin_install_script=plugin_install_script,
-                plugin_install_language=plugin_install_language,
-                plugin_install_dependencies=plugin_install_dependencies,
-                plugin_configuration_path=plugin_configuration_path
-            ))
+            ".format(
+                    plugin_config=plugin_config,
+                    plugin_install_script=plugin_install_script,
+                    plugin_install_language=plugin_install_language,
+                    plugin_install_dependencies=plugin_install_dependencies,
+                    plugin_configuration_path=plugin_configuration_path,
+                )
+            )
 
             os.chmod(plugin_install_script_path, 775)
             if os.path.isfile(plugin_install_script_path):
-                result = subprocess.run([plugin_install_language, plugin_install_script_path], 
-                    universal_newlines = True,
-                    capture_output=True, 
-                    #shell=True
-                    )
+                result = subprocess.run(
+                    [plugin_install_language, plugin_install_script_path],
+                    universal_newlines=True,
+                    capture_output=True,
+                    # shell=True
+                )
                 if result.returncode == 0:
-                    logger.info("\n~#~#~#~INSTALLING PLUGIN [{plugin_config}] SUCCESSFULLY COMPLETED~#~#~#~".format(plugin_config=plugin_config))
-                    logger.debug("\n\tSTDOUT:[{stdout}]\n\tSTDERR: [{stderr}]\n\tRESULTS: [{result}]".format(stdout=result.stdout, stderr=result.stderr, result=result))
+                    logger.info(
+                        "\n~#~#~#~INSTALLING PLUGIN [{plugin_config}] SUCCESSFULLY COMPLETED~#~#~#~".format(
+                            plugin_config=plugin_config
+                        )
+                    )
+                    logger.debug(
+                        "\n\tSTDOUT:[{stdout}]\n\tSTDERR: [{stderr}]\n\tRESULTS: [{result}]".format(
+                            stdout=result.stdout, stderr=result.stderr, result=result
+                        )
+                    )
                 else:
-                    logger.error("\n~#~#~#~INSTALLING PLUGIN [{plugin_config}] FAILED~#~#~#~".format(plugin_config=plugin_config))
-                    logger.debug("\n\tSTDOUT:[{stdout}]\n\tSTDERR: [{stderr}]\n\tRESULTS: [{result}]".format(stdout=result.stdout, stderr=result.stderr, result=result))
+                    logger.error(
+                        "\n~#~#~#~INSTALLING PLUGIN [{plugin_config}] FAILED~#~#~#~".format(
+                            plugin_config=plugin_config
+                        )
+                    )
+                    logger.debug(
+                        "\n\tSTDOUT:[{stdout}]\n\tSTDERR: [{stderr}]\n\tRESULTS: [{result}]".format(
+                            stdout=result.stdout, stderr=result.stderr, result=result
+                        )
+                    )
                     sys.exit(result.returncode)
-                
+
             else:
-                logger.error("File does not exist: [{}]".format(plugin_install_script_path))
+                logger.error(
+                    "File does not exist: [{}]".format(plugin_install_script_path)
+                )
                 sys.exit(1)
         else:
-            logger.error("Plugin source cannot be empty. Plugin: [{}] Download did not run".format(plugin_config))
+            logger.error(
+                "Plugin source cannot be empty. Plugin: [{}] Download did not run".format(
+                    plugin_config
+                )
+            )
             sys.exit(1)

--- a/scripts/plugins/logging.py
+++ b/scripts/plugins/logging.py
@@ -8,12 +8,18 @@ from .settings import BITOPS_logging_level
 # 3. WARN
 # 4. ERROR
 
-from .settings import BITOPS_logging_level, BITOPS_logging_color, BITOPS_logging_filename, BITOPS_logging_path
+from .settings import (
+    BITOPS_logging_level,
+    BITOPS_logging_color,
+    BITOPS_logging_filename,
+    BITOPS_logging_path,
+)
 
 BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE = range(8)
 RESET_SEQ = "\033[0m"
 COLOR_SEQ = "\033[1;%dm"
 BOLD_SEQ = "\033[1m"
+
 
 def formatter_message(message, use_color=BITOPS_logging_color):
     if use_color:
@@ -22,13 +28,15 @@ def formatter_message(message, use_color=BITOPS_logging_color):
         message = message.replace("$RESET", "").replace("$BOLD", "")
     return message
 
+
 COLORS = {
-    'DEBUG': BLUE,
-    'INFO': GREEN,
-    'WARNING': YELLOW,
-    'ERROR': RED,
-    'CRITICAL': MAGENTA
+    "DEBUG": BLUE,
+    "INFO": GREEN,
+    "WARNING": YELLOW,
+    "ERROR": RED,
+    "CRITICAL": MAGENTA,
 }
+
 
 class ColoredFormatter(logging.Formatter):
     def __init__(self, msg, use_color=BITOPS_logging_color):
@@ -38,7 +46,9 @@ class ColoredFormatter(logging.Formatter):
     def format(self, record):
         levelname = record.levelname
         if self.use_color and levelname in COLORS:
-            levelname_color = COLOR_SEQ % (30 + COLORS[levelname]) + levelname + RESET_SEQ
+            levelname_color = (
+                COLOR_SEQ % (30 + COLORS[levelname]) + levelname + RESET_SEQ
+            )
             record.levelname = levelname_color
         return logging.Formatter.format(self, record)
 
@@ -48,20 +58,25 @@ logger.setLevel(BITOPS_logging_level)
 
 handler = logging.StreamHandler(sys.stdout)
 handler.setLevel(BITOPS_logging_level)
-formatter = ColoredFormatter(formatter_message('%(asctime)s %(name)-12s %(levelname)-8s %(message)s'))
+formatter = ColoredFormatter(
+    formatter_message("%(asctime)s %(name)-12s %(levelname)-8s %(message)s")
+)
 
 handler.setFormatter(formatter)
 logger.addHandler(handler)
 
 if BITOPS_logging_filename is not None:
     # This assumes that the user wants to save output to a filename
-    
+
     # Create the directory if it doesn't exist
     from pathlib import Path
+
     Path(BITOPS_logging_path).mkdir(parents=True, exist_ok=True)
 
     BITOPS_logging_filename.replace(".logs", "").replace(".log", "")
 
-    fileHandler = logging.FileHandler("{0}/{1}.log".format(BITOPS_logging_path, BITOPS_logging_filename))
+    fileHandler = logging.FileHandler(
+        "{0}/{1}.log".format(BITOPS_logging_path, BITOPS_logging_filename)
+    )
     fileHandler.setFormatter(formatter)
     logger.addHandler(fileHandler)

--- a/scripts/plugins/settings.py
+++ b/scripts/plugins/settings.py
@@ -4,26 +4,32 @@ import argparse
 
 from munch import DefaultMunch
 
-parser = argparse.ArgumentParser(description='Add BitOps Usage')
-parser.add_argument('--bitops_config_file', "-c", help='BitOps source usage information here')
+parser = argparse.ArgumentParser(description="Add BitOps Usage")
+parser.add_argument(
+    "--bitops_config_file", "-c", help="BitOps source usage information here"
+)
 
 BITOPS_CL_args, unknowns = parser.parse_known_args()
 
 # BitOps Configuration file
-BITOPS_ENV_config_file = os.environ.get("BITOPS_BUILD_CONFIG_YAML") 
-BITOPS_config_file = BITOPS_ENV_config_file                         \
-    if BITOPS_ENV_config_file is not None                        \
-    else BITOPS_CL_args.bitops_config_file               \
-        if BITOPS_CL_args.bitops_config_file is not None  \
-        else "bitops.config.yaml"
-with open(BITOPS_config_file, 'r') as stream:
+BITOPS_ENV_config_file = os.environ.get("BITOPS_BUILD_CONFIG_YAML")
+BITOPS_config_file = (
+    BITOPS_ENV_config_file
+    if BITOPS_ENV_config_file is not None
+    else BITOPS_CL_args.bitops_config_file
+    if BITOPS_CL_args.bitops_config_file is not None
+    else "bitops.config.yaml"
+)
+with open(BITOPS_config_file, "r") as stream:
     BITOPS_config_yaml = yaml.load(stream, Loader=yaml.FullLoader)
 
-BITOPS_ENV_schema_file = os.environ.get("BITOPS_BUILD_SCHEMA_YAML") 
-BITOPS_schema_file = BITOPS_ENV_schema_file                       \
-    if BITOPS_ENV_schema_file is not None                        \
+BITOPS_ENV_schema_file = os.environ.get("BITOPS_BUILD_SCHEMA_YAML")
+BITOPS_schema_file = (
+    BITOPS_ENV_schema_file
+    if BITOPS_ENV_schema_file is not None
     else "bitops.schema.yaml"
-with open(BITOPS_schema_file, 'r') as stream:
+)
+with open(BITOPS_schema_file, "r") as stream:
     BITOPS_schema_yaml = yaml.load(stream, Loader=yaml.FullLoader)
 
 # Updating from Bitops build config
@@ -31,69 +37,91 @@ bitops_build_configuration = DefaultMunch.fromDict(BITOPS_config_yaml, None)
 bitops_schema_configuration = DefaultMunch.fromDict(BITOPS_schema_yaml, None)
 
 # ENVIRONMENT
-BITOPS_ENV_fast_fail_mode   = os.environ.get("BITOPS_FAST_FAIL")
-BITOPS_ENV_run_mode         = os.environ.get("BITOPS_MODE")
-BITOPS_ENV_logging_level    = os.environ.get("BITOPS_LOGGING_LEVEL")
-BITOPS_ENV_plugin_dir       = os.environ.get("BITOPS_PLUGIN_DIR")
+BITOPS_ENV_fast_fail_mode = os.environ.get("BITOPS_FAST_FAIL")
+BITOPS_ENV_run_mode = os.environ.get("BITOPS_MODE")
+BITOPS_ENV_logging_level = os.environ.get("BITOPS_LOGGING_LEVEL")
+BITOPS_ENV_plugin_dir = os.environ.get("BITOPS_PLUGIN_DIR")
 
-BITOPS_ENV_default_folder   = os.environ.get("BITOPS_DEFAULT_FOLDER")
+BITOPS_ENV_default_folder = os.environ.get("BITOPS_DEFAULT_FOLDER")
 # v2.0.0: Fallback to 'ENVIRONMENT' in case when 'BITOPS_ENVIRONMENT' is not set
 # TODO: Drop 'ENVIRONMENT' backward-compatibility in the future versions
-BITOPS_ENV_environment      = os.environ.get("BITOPS_ENVIRONMENT", os.environ.get("ENVIRONMENT", None))
-BITOPS_ENV_timeout          = os.environ.get("BITOPS_TIMEOUT")
+BITOPS_ENV_environment = os.environ.get(
+    "BITOPS_ENVIRONMENT", os.environ.get("ENVIRONMENT", None)
+)
+BITOPS_ENV_timeout = os.environ.get("BITOPS_TIMEOUT")
 
 if not bitops_build_configuration.bitops:
-    sys.stderr.write(f"Error: Invalid {BITOPS_config_file}: 'bitops' at the root level definition is required!")
+    sys.stderr.write(
+        f"Error: Invalid {BITOPS_config_file}: 'bitops' at the root level definition is required!"
+    )
     sys.exit(1)
 
 # WASHED VALUES
 # This is just stacked ternary operators. Don't be scared. All this does is X if X is set, Y if Y is set, else default value
-BITOPS_fast_fail_mode = BITOPS_ENV_fast_fail_mode                   \
-    if BITOPS_ENV_fast_fail_mode is not None                        \
-    else bitops_build_configuration.bitops.fail_fast                \
-        if bitops_build_configuration.bitops.fail_fast is not None  \
-        else True
+BITOPS_fast_fail_mode = (
+    BITOPS_ENV_fast_fail_mode
+    if BITOPS_ENV_fast_fail_mode is not None
+    else bitops_build_configuration.bitops.fail_fast
+    if bitops_build_configuration.bitops.fail_fast is not None
+    else True
+)
 
-BITOPS_run_mode = BITOPS_ENV_run_mode                               \
-    if BITOPS_ENV_run_mode is not None                              \
-    else bitops_build_configuration.bitops.run_mode                 \
-        if bitops_build_configuration.bitops.run_mode is not None   \
-        else "default"
+BITOPS_run_mode = (
+    BITOPS_ENV_run_mode
+    if BITOPS_ENV_run_mode is not None
+    else bitops_build_configuration.bitops.run_mode
+    if bitops_build_configuration.bitops.run_mode is not None
+    else "default"
+)
 
-BITOPS_logging_level = BITOPS_ENV_logging_level                         \
-    if BITOPS_ENV_logging_level is not None                             \
-    else bitops_build_configuration.bitops.logging.level                \
-        if bitops_build_configuration.bitops.logging.level is not None  \
-        else "DEBUG"
+BITOPS_logging_level = (
+    BITOPS_ENV_logging_level
+    if BITOPS_ENV_logging_level is not None
+    else bitops_build_configuration.bitops.logging.level
+    if bitops_build_configuration.bitops.logging.level is not None
+    else "DEBUG"
+)
 
-BITOPS_logging_color = bitops_build_configuration.bitops.logging.color.enabled                      \
-    if bitops_build_configuration.bitops.logging.color.enabled is not None  \
+BITOPS_logging_color = (
+    bitops_build_configuration.bitops.logging.color.enabled
+    if bitops_build_configuration.bitops.logging.color.enabled is not None
     else False
+)
 
-BITOPS_logging_filename = bitops_build_configuration.bitops.logging.filename                      \
-    if bitops_build_configuration.bitops.logging.filename is not None  \
+BITOPS_logging_filename = (
+    bitops_build_configuration.bitops.logging.filename
+    if bitops_build_configuration.bitops.logging.filename is not None
     else None
+)
 
-BITOPS_logging_path = bitops_build_configuration.bitops.logging.path                      \
-    if bitops_build_configuration.bitops.logging.path is not None  \
+BITOPS_logging_path = (
+    bitops_build_configuration.bitops.logging.path
+    if bitops_build_configuration.bitops.logging.path is not None
     else "/var/log/bitops"
+)
 
 
-BITOPS_plugin_dir = BITOPS_ENV_plugin_dir                         \
-    if BITOPS_ENV_plugin_dir is not None                             \
-    else bitops_build_configuration.bitops.plugins.plugin_dir               \
-        if bitops_build_configuration.bitops.plugins.plugin_dir is not None  \
-        else "/opt/bitops/scripts/plugins/"
+BITOPS_plugin_dir = (
+    BITOPS_ENV_plugin_dir
+    if BITOPS_ENV_plugin_dir is not None
+    else bitops_build_configuration.bitops.plugins.plugin_dir
+    if bitops_build_configuration.bitops.plugins.plugin_dir is not None
+    else "/opt/bitops/scripts/plugins/"
+)
 
 
-BITOPS_default_folder = BITOPS_ENV_default_folder   \
-    if BITOPS_ENV_default_folder is not None        \
-    else bitops_build_configuration.bitops.default_folder               \
-        if bitops_build_configuration.bitops.default_folder is not None \
-        else "_default"
+BITOPS_default_folder = (
+    BITOPS_ENV_default_folder
+    if BITOPS_ENV_default_folder is not None
+    else bitops_build_configuration.bitops.default_folder
+    if bitops_build_configuration.bitops.default_folder is not None
+    else "_default"
+)
 
-BITOPS_timeout = BITOPS_ENV_timeout   \
-    if BITOPS_ENV_timeout is not None        \
-    else bitops_build_configuration.bitops.timeout               \
-        if bitops_build_configuration.bitops.timeout is not None \
-        else 600
+BITOPS_timeout = (
+    BITOPS_ENV_timeout
+    if BITOPS_ENV_timeout is not None
+    else bitops_build_configuration.bitops.timeout
+    if bitops_build_configuration.bitops.timeout is not None
+    else 600
+)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,2 @@
+black
+tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,25 @@
+# Tox standardizes testing environments in python
+# https://tox.wiki/
+#
+# Run:
+#      tox
+[tox]
+envlist = py38,black
+skipsdist = True
+
+[testenv]
+install_command = pip install -U {opts} {packages}
+setenv = VIRTUAL_ENV={envdir}
+
+deps = -r{toxinidir}/test-requirements.txt
+       -r{toxinidir}/requirements.txt
+
+# Black enforces common code formatting
+# https://black.readthedocs.io/en/stable/
+#
+# Run:
+#      tox -e black
+[testenv:black]
+skip_install = True
+commands =
+       black --config pyproject.toml --check --diff scripts/


### PR DESCRIPTION
This PR adds `black` tool which enforces code formatting according to the common python standards.
See https://black.readthedocs.io/en/stable/

It's the start of a future series of PRs focused on improving the codebase standards, adding tests, and enforcing the CI checks that are expected from the project with the python codebase. See https://github.com/bitovi/bitops/projects/4 project. Partially implements https://github.com/bitovi/bitops/issues/271


- [x] Add `black` - code reformatting tool
- [x] Add `tox` - pipeline/venv test runner
- [x] Add `test-requirements.txt`
- [x] Reformat python code with `black`
- [x] Run `black` in CI GH Actions for every PR
- [x] Update the development docs with instructions


Example quick start instructions:
```
pip3 install tox
tox -e black
```
