### PR TITLE
Fix the CI status not showing for the main branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ---------------------
 
-[![Build Status](https://github.com/bitovi/bitops/actions/workflows/ci.yaml/badge.svg)](https://github.com/bitovi/bitops/actions/workflows/ci.yaml)
+[![Build Status](https://github.com/bitovi/bitops/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/bitovi/bitops/actions/workflows/ci.yaml)
 [![LICENSE](https://img.shields.io/badge/license-MIT-green)](LICENSE.md)
 ![Python 3.8](https://img.shields.io/badge/python-3.8-blue)
 [![Latest Release](https://img.shields.io/github/v/release/bitovi/bitops)](https://github.com/bitovi/bitops/releases)


### PR DESCRIPTION
#297 introduced CI workflow with the first python listing check. Quick fix a couple of small oversights:
- Fix the new CI workflow is not triggering for the `main` branch pushes because of `master` being in the rules.
- Filter the CI badge on the README to show status for the `main` branch only