### PR TITLE
Docs: Roadmap page

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -23,6 +23,11 @@ Create an Issue, open a Discussion, join our Community and we'll be happy to wor
 Check the [`main`](https://github.com/bitovi/bitops) repository branch to see the ongoing development.
 
 ## Release History
+### Done in v2.1.0
+  - **Community:** Start bi-weekly [BitOps Community Meetings](https://github.com/bitovi/bitops/discussions?discussions_q=label%3Atype%3Ameeting)
+  - **Plugins:** Package the latest tools versions by default in the official BitOps image
+  - **Code:** Introduce `black` tool for enforcing the common python code formatting style
+
 ### Done in v2.0.0
   - **Core:** Rewrite the engine with Python instead of bash
   - **Plugins:** New system to compose the BitOps image with the custom tools

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,34 @@
+# Roadmap
+
+This is a BitOps roadmap. It represents our current project direction.
+BitOps is still a young project under brainstorming and heavy development.
+
+If there’s something you need or have an idea, remember: this is Open Source.
+Create an Issue, open a Discussion, join our Community and we'll be happy to work on shaping the project's future together.
+
+## Backlog
+- **Documentation:** Getting started guide
+- **Documentation:** BitOps vs other tools comparison
+- **CLI:** Ops repo generator
+- **Plugins:** Custom version pinning
+- **Community:** Ops repo catalog
+- **Core:** Automated testing
+- **Plugins:** Automated testing and validation
+- **Core:** Run a deployment sub-step per tool
+- **Plugins:** Support for private repositories
+- **Core:** Schema validation and enhancements
+- **Security:** Secrets masking
+
+Check the [`main`](https://github.com/bitovi/bitops) repository branch to see the ongoing development.
+
+## Release History
+### Done in v2.0.0
+  - **Core:** Rewrite the engine with Python instead of bash
+  - **Plugins:** New system to compose the BitOps image with the custom tools
+  - **Plugins:** Plugins catalog [github.com/bitops-plugins](https://github.com/bitops-plugins/)
+  - **Images:** New official images: omnibus, aws-ansible, aws-terraform, aws-helm
+  - **Releases:** New docker tagging strategy
+
+### Done in v1.0.0
+  - Ops Repository concept
+  - Initial implementation in bash

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,6 +15,7 @@ Create an Issue, open a Discussion, join our Community and we'll be happy to wor
 - **Core:** Automated testing
 - **Plugins:** Automated testing and validation
 - **Core:** Run a deployment sub-step per tool
+- **Core:** Schema validation and error reporting
 - **Plugins:** Support for private repositories
 - **Core:** Schema validation and enhancements
 - **Security:** Secrets masking

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,16 +35,18 @@ nav:
       - Helm: tool-configuration/configuration-helm.md
       - Cloudformation: tool-configuration/configuration-cloudformation.md
     - Default Environment: default-environment.md
-    - BitOps Versioning: versioning.md
   - Examples: examples.md
-  - Upgrade:
-    - v2.0: migration/2.0-migration.md
+  - Releases:
+    - Versioning: versioning.md
+    - Roadmap: roadmap.md
+    - Upgrade:
+      - v2.0: migration/2.0-migration.md
   - Development:
     - Local development: development-local.md
     - Custom Images: custom-image.md
   - Plugins: plugins.md
   - Lifecycle: lifecycle.md
-  - About: 
+  - About:
     - About: about.md
     - Contributing:
       - Contributing Guide: contributing.md


### PR DESCRIPTION
Adds an initial Roadmap page with some major features discussed during the [BitOps Community Meeting (12 Oct 2022): v2.1.0 Release, Roadmap #319](https://github.com/bitovi/bitops/discussions/319). Comments and additions are welcome.

Not sure yet what would be the best place for the Roadmap page?
I’m thinking about refactoring the structure a bit:
```
- Releases <-- new category
  - Roadmap
  - Upgrade:
    - v2.0: migration
  - Versioning
```
Any better ideas?