### PR TITLE
Update docs site url and add CNAME file for new bitops.sh

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+bitops.sh

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: BitOps Documentation
 # Set site_url when we have a real domain
-# site_url: http://bitops.works/
+site_url: https://bitops.sh
 
 theme:
   features:


### PR DESCRIPTION
Our `bitops.sh` site url is removed from time to time.  

Some places (such as [this](https://lightrun.com/answers/l33t-kr3w-push-dir-custom-domain-is-deleted-from-settings)) suggest that it might be when changes are deployed to gh-pages and recommend to add `CNAME`.