### PR TITLE
[WIP] closes #298 - add masking functions to be called in logger and directly

### DIFF
--- a/prebuilt-config/omnibus/bitops.config.yaml
+++ b/prebuilt-config/omnibus/bitops.config.yaml
@@ -13,6 +13,18 @@ bitops:
     filename: bitops-run      # log filename
     err: bitops.logs          # error logs filename
     path: /var/logs/bitops    # path to log folder
+    # Define the secrets to mask
+    masks:
+      - # regex to search
+        # looks for `BITOPS_KUBECONFIG_BASE64={string}`
+        search:  (.*BITOPS_KUBECONFIG_BASE64.*\=)(.*\n)
+        # replace the value part
+        replace: '\1*******\n'
+      - # regex to search
+        # looks for `The namespace kube-system exists`
+        search:  (.*The namespace )(kube-system)( exists.*)
+        #replace kube-system
+        replace: '\1*******\3'
   default_folder: _default
   plugins:    
     aws:

--- a/scripts/plugins/logging.py
+++ b/scripts/plugins/logging.py
@@ -1,7 +1,6 @@
 import logging
 import re
 import sys
-from munch import DefaultMunch
 
 from .settings import (
     BITOPS_logging_level,
@@ -34,6 +33,10 @@ COLORS = {
 
 # TODO: move to its own file so it can be used by plugins and before/after hooks
 def mask_message(message):
+    """
+    Given a message, applies a mask according to the
+    bitops level bitops.config.yaml's bitops.logging.mask property
+    """
     if message is None:
         return message
 
@@ -58,7 +61,7 @@ def formatter_message(message, use_color=BITOPS_logging_color):
     return message
 
 
-class BITOPS_Formatter(logging.Formatter):
+class BitOpsFormatter(logging.Formatter):
     """
     Class that controls the formatting of logging text, adds colors if enabled.
     Settings are contained within "bitops.config.yaml:bitops.logging".
@@ -83,7 +86,7 @@ class BITOPS_Formatter(logging.Formatter):
         return logging.Formatter.format(self, record)
 
 
-formatter = BITOPS_Formatter(
+formatter = BitOpsFormatter(
     formatter_message("%(asctime)s %(name)-12s %(levelname)-8s %(message)s")
 )
 

--- a/scripts/plugins/logging.py
+++ b/scripts/plugins/logging.py
@@ -8,7 +8,7 @@ from .settings import (
     BITOPS_logging_color,
     BITOPS_logging_filename,
     BITOPS_logging_path,
-    bitops_build_configuration,
+    BITOPS_logging_masks,
 )
 
 
@@ -32,19 +32,13 @@ COLORS = {
 }
 
 
-def get_mask_config():
-    # read the root bitops config
-    bitops_dir = "/opt/bitops"
-    return DefaultMunch.fromDict(bitops_build_configuration.bitops.logging.masks, None)
-
-
 # TODO: move to its own file so it can be used by plugins and before/after hooks
 def mask_message(message):
     if message is None:
         return message
 
     res_str = message
-    for config_item in get_mask_config():
+    for config_item in BITOPS_logging_masks:
         # TODO: use a library here?
         res_str = re.sub(rf"{config_item.search}", config_item.replace, str(res_str))
     # String after replacement

--- a/scripts/plugins/logging.py
+++ b/scripts/plugins/logging.py
@@ -8,7 +8,7 @@ from .settings import (
     BITOPS_logging_color,
     BITOPS_logging_filename,
     BITOPS_logging_path,
-    bitops_build_configuration
+    bitops_build_configuration,
 )
 
 
@@ -35,22 +35,21 @@ COLORS = {
 def get_mask_config():
     # read the root bitops config
     bitops_dir = "/opt/bitops"
-    return DefaultMunch.fromDict(
-        bitops_build_configuration.bitops.logging.masks, None
-    )
+    return DefaultMunch.fromDict(bitops_build_configuration.bitops.logging.masks, None)
+
 
 # TODO: move to its own file so it can be used by plugins and before/after hooks
 def mask_message(message):
     if message is None:
         return message
 
-    res_str=message
+    res_str = message
     for config_item in get_mask_config():
         # TODO: use a library here?
         res_str = re.sub(rf"{config_item.search}", config_item.replace, str(res_str))
     # String after replacement
     return res_str
-  
+
 
 def formatter_message(message, use_color=BITOPS_logging_color):
     """
@@ -63,6 +62,7 @@ def formatter_message(message, use_color=BITOPS_logging_color):
         message = message.replace("$RESET", "").replace("$BOLD", "")
 
     return message
+
 
 class BITOPS_Formatter(logging.Formatter):
     """
@@ -87,6 +87,7 @@ class BITOPS_Formatter(logging.Formatter):
         record.msg = mask_message(record.msg)
 
         return logging.Formatter.format(self, record)
+
 
 formatter = BITOPS_Formatter(
     formatter_message("%(asctime)s %(name)-12s %(levelname)-8s %(message)s")

--- a/scripts/plugins/settings.py
+++ b/scripts/plugins/settings.py
@@ -122,3 +122,9 @@ BITOPS_timeout = (
     if bitops_build_configuration.bitops.timeout is not None
     else 600
 )
+
+BITOPS_logging_masks = (
+    bitops_build_configuration.bitops.logging.masks
+    if bitops_build_configuration.bitops.logging.masks is not None
+    else None
+)

--- a/scripts/plugins/utilities.py
+++ b/scripts/plugins/utilities.py
@@ -365,7 +365,8 @@ def run_cmd(command: Union[list, str]) -> subprocess.CompletedProcess:
                 # TODO: can we modify a specific handler to add handler.terminator = "" ?
                 sys.stdout.write(mask_message(combined_output))
 
-            # This polls the async function to get information about the status of the process execution.
+            # This polls the async function to get information 
+            # about the status of the process execution.
             # Namely the return code which is used elsewhere.
             process.communicate()
     except Exception as exc:

--- a/scripts/plugins/utilities.py
+++ b/scripts/plugins/utilities.py
@@ -365,7 +365,7 @@ def run_cmd(command: Union[list, str]) -> subprocess.CompletedProcess:
                 # TODO: can we modify a specific handler to add handler.terminator = "" ?
                 sys.stdout.write(mask_message(combined_output))
 
-            # This polls the async function to get information 
+            # This polls the async function to get information
             # about the status of the process execution.
             # Namely the return code which is used elsewhere.
             process.communicate()

--- a/scripts/plugins/utilities.py
+++ b/scripts/plugins/utilities.py
@@ -7,7 +7,7 @@ import yaml
 
 from munch import DefaultMunch
 from .doc import get_doc
-from .logging import logger
+from .logging import logger, mask_message
 from .settings import (
     BITOPS_fast_fail_mode,
     BITOPS_config_file,
@@ -363,7 +363,7 @@ def run_cmd(command: Union[list, str]) -> subprocess.CompletedProcess:
                 # TODO: parse output for secrets
                 # TODO: specify plugin and output tight output (no extra newlines)
                 # TODO: can we modify a specific handler to add handler.terminator = "" ?
-                sys.stdout.write(combined_output)
+                sys.stdout.write(mask_message(combined_output))
 
             # This polls the async function to get information about the status of the process execution.
             # Namely the return code which is used elsewhere.


### PR DESCRIPTION
# Description

Add configuration in the bitops-level bitops.config to add masks based on regular expressions.

## Todo
- [ ] add a setting for turning masking on or off (on by default, include a warning if it's turned off)
- [ ] There's a TODO to look into a library and swap out the regex format if necessary, but I think this is a good start
- [ ] ops-repo bitops.config.yaml support for custom masking at the ops-repo level
- [ ] docs

Fixes #208

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Tested locally with `BITOPS_KUBECONFIG_BASE64` (see [this pr](https://github.com/bitovi/bitops/pull/340/files#diff-cd75a1902c8431c5f453af04821c50079b73201755e7bd429c94503842c38c7eR2) for the local development setup used)


**Logs**
without change:
```
~#~#~#~BITOPS ENVIRONMENT VARIABLES~#~#~#~
	BITOPS_DEFAULT_ROOT_DIR=_default
	BITOPS_DIR=/opt/bitops
	BITOPS_ENVIRONMENT=prod
	BITOPS_ENVROOT=/tmp/tmplcry4xqb/prod
	BITOPS_FAIL_FAST=True
	BITOPS_KUBECONFIG_BASE64=uueagqwugv8a4isbviaw9ah49h9g39vba4ba4v9wvofgairgw
```

with changes:
```
~#~#~#~BITOPS ENVIRONMENT VARIABLES~#~#~#~
	BITOPS_DEFAULT_ROOT_DIR=_default
	BITOPS_DIR=/opt/bitops
	BITOPS_ENVIRONMENT=prod
	BITOPS_ENVROOT=/tmp/tmplcry4xqb/prod
	BITOPS_FAIL_FAST=True
	BITOPS_KUBECONFIG_BASE64=*******
```

**Test Configuration**: (see below)
* BitOps image tag used: 2.1.0
* Tool/plugin: n/a

mask config: modified the omnibus `bitops.config.yaml` to include new mask configuration
command:
```
docker run --rm --name bitops \
-e AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
-e AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
-e AWS_SESSION_TOKEN="${AWS_SESSION_TOKEN}" \
-e AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION}" \
-e BITOPS_ENVIRONMENT="prod" \
-e SKIP_DEPLOY_TERRAFORM="true" \
-e SKIP_DEPLOY_HELM="true" \
-e DEFAULT_FOLDER_NAME="_default" \
-e BITOPS_KUBECONFIG_BASE64="${BITOPS_KUBECONFIG_BASE64}" \
-e PYTHONUNBUFFERED=1 \
-v /path/to/bitops:/opt/bitops \
-v /path/to/operations-repo:/opt/bitops_deployment \
-v /path/to/bitops/prebuilt-config/omnibus/bitops.config.yaml:/opt/bitops/bitops.config.yaml \
-v /opt/bitops/scripts/plugins/aws \
-v /opt/bitops/scripts/plugins/cloudformation \
-v /opt/bitops/scripts/plugins/kubectl \
-v /opt/bitops/scripts/plugins/ansible \
-v /path/to/bitops-plugins/helm:/opt/bitops/scripts/plugins/helm \
-v /path/to/bitops-plugins/terraform:/opt/bitops/scripts/plugins/terraform \
--entrypoint "python3" \
bitovi/bitops:2.1.0 \
/opt/bitops/scripts/main.py deploy
```

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
