### PR TITLE
Fix error when there's an empty 'mask' in bitops config

### DIFF
--- a/scripts/plugins/logging.py
+++ b/scripts/plugins/logging.py
@@ -39,6 +39,8 @@ def mask_message(message):
     """
     if message is None:
         return message
+    if BITOPS_logging_masks is None:
+        return message
 
     res_str = message
     for config_item in BITOPS_logging_masks:


### PR DESCRIPTION
# Description

Adding mask value check. If value is set, masking will occur, if not, message it returned unmasked. This avoid null value issues. 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
