### PR TITLE
Fix BitOps failing on empty plugin config sub-items

### DIFF
--- a/scripts/plugins/utilities.py
+++ b/scripts/plugins/utilities.py
@@ -193,7 +193,7 @@ def get_nested_item(search_dict, key):
     try:
         for k in key_list:
             obj = obj[k]
-    except KeyError:
+    except (KeyError, TypeError):
         return None
     logger.debug(f"\n\t\tKEY [{key}] \n\t\tRESULT FOUND:   [{obj}]")
     return obj


### PR DESCRIPTION
Fixes #332 when BitOps deployment run fails with the error:
```
Traceback (most recent call last):
  File "/opt/bitops/scripts/plugins.py", line 49, in <module>
    Deploy_Plugins()
  File "/opt/bitops/scripts/plugins/deploy_plugins.py", line 226, in Deploy_Plugins
    cli_config_list, options_config_list = Get_Config_List(
  File "/opt/bitops/scripts/plugins/utilities.py", line 277, in Get_Config_List
    schema_object.ProcessConfig(config_yaml)
  File "/opt/bitops/scripts/plugins/utilities.py", line 98, in ProcessConfig
    result = Get_Nested_Item(config_yaml, self.config_key)
  File "/opt/bitops/scripts/plugins/utilities.py", line 194, in Get_Nested_Item
    obj = obj[k]
TypeError: 'NoneType' object is not subscriptable
```
in case when any of the plugin's `bitops.config.yaml` setting is empty, like:

```diff
terraform:
-   cli: {}
+   cli:
    options:
        stack-action: apply
        fetch-kubeconfig: false
```

The config sub-items instead should be populated with the config schema defaults like https://github.com/bitops-plugins/terraform/blob/main/bitops.schema.yaml