### PR TITLE
Exit with the error on unsupported bitops schema data type in fail_fast mode

### DIFF
--- a/scripts/plugins/utilities.py
+++ b/scripts/plugins/utilities.py
@@ -55,8 +55,9 @@ class SchemaObject:  # pylint: disable=too-many-instance-attributes
                     setattr(self, _property, schema_property_values[_property])
                 except KeyError as exc:
                     setattr(self, _property, None)
+                    logger.error(exc)
                     if BITOPS_fast_fail_mode:
-                        raise exc
+                        sys.exit(101)
 
         logger.info(f"\n\tNEW SCHEMA:{self.print_schema()}")
 
@@ -158,7 +159,8 @@ def apply_data_type(data_type, convert_value):
         return bool(convert_value)
 
     if BITOPS_fast_fail_mode:
-        raise ValueError(f"Data type not supported: [{data_type}]")
+        logger.error(f"Data type not supported: [{data_type}]")
+        sys.exit(101)
 
     logger.warning(f"Data type not supported: [{data_type}]")
     return None


### PR DESCRIPTION
# Description

Small update to the exit logic for fail fast usage, this is to properly support our Github Action usage

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested locally

**Logs**

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
