### PR TITLE
Fix BitOps to pass lowercase booleans based on plugin schema defaults

### DIFF
--- a/scripts/plugins/utilities.py
+++ b/scripts/plugins/utilities.py
@@ -177,9 +177,12 @@ def add_value_to_env(export_env, value):
     if value is None or value == "" or value == "None" or export_env is None or export_env == "":
         return
 
+    if isinstance(value, bool):
+        value = str(value).lower()
+
     export_env = "BITOPS_" + export_env
     os.environ[export_env] = str(value)
-    logger.info("Setting environment variable: [{export_env}], to value: [{value}]")
+    logger.info(f"Setting environment variable: [{export_env}], to value: [{value}]")
 
 
 def get_nested_item(search_dict, key):


### PR DESCRIPTION
# Description

Values returned to BitOps plugins parsed from the config schema are being returned with uppercase booleans (true -> True), while the lowercase is expected.

Fixes #357 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Live session