### PR TITLE
chore: update Dockerfile to reduce the image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV PYTHONUNBUFFERED=1
 RUN apk add --no-cache bash
 RUN apk update
 
-RUN apk add \
+RUN apk add --no-cache \
     libsodium-dev \
     wget \
     unzip \
@@ -14,7 +14,7 @@ RUN apk add \
     curl \
     rsync \
     openssh
-    
+
 # install glibc compatibility for alpine
 ENV GLIBC_VER=2.31-r0
 RUN mkdir -p /opt/bitops
@@ -26,7 +26,7 @@ COPY bitops.config.yaml .
 COPY bitops.schema.yaml .
 COPY requirements.txt .
 
-RUN pip3 install -r requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
 
 # temporarily set the working dir to `/opt/bitops-local-plugins`
 #    to copy local plugins from a custom bitops repo into the container


### PR DESCRIPTION
# Description

Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size.

Summary of the changes:
* I added the `--no-cache-dir` to the `pip` command to disable the package cache.
* I added `--no-cache` flag to `apk add` to ensure that no useless information is kept inside the Docker image.


Impact on the image size:
* Image size before repair: 168.45 MB
* Image size after repair: 156.13 MB
* Difference: 12.31 MB (7.31%)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

I build the Docker Image with and without the changes and I check the impact on the Docker image size.
The proposed changes do not change the behavior of the image.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
