### PR TITLE
Adding environment variable check, if found ignore bitops.config attr…

### DIFF
--- a/scripts/plugins/utilities.py
+++ b/scripts/plugins/utilities.py
@@ -176,6 +176,10 @@ def add_value_to_env(export_env, value):
     """
     if value is None or value == "" or value == "None" or export_env is None or export_env == "":
         return
+    
+    if os.environ.get('BITOPS_'+export_env):
+        logger.info("Environment Varible alredy set. Configuration value ignored.")
+        return
 
     if isinstance(value, bool):
         value = str(value).lower()

--- a/scripts/plugins/utilities.py
+++ b/scripts/plugins/utilities.py
@@ -178,7 +178,9 @@ def add_value_to_env(export_env, value):
         return
     export_env = "BITOPS_" + export_env
     if os.environ.get(export_env):
-        logger.info(f"Environment Varible [{export_env}] already set. BitOps Configuration value ignored.")
+        logger.info(
+            f"Environment variable [{export_env}] already set. BitOps configuration value ignored."
+        )
         return
 
     if isinstance(value, bool):

--- a/scripts/plugins/utilities.py
+++ b/scripts/plugins/utilities.py
@@ -176,14 +176,13 @@ def add_value_to_env(export_env, value):
     """
     if value is None or value == "" or value == "None" or export_env is None or export_env == "":
         return
-    if os.environ.get("BITOPS_" + export_env):
+    export_env = "BITOPS_" + export_env
+    if os.environ.get(export_env):
         logger.info("Environment Varible alredy set. Configuration value ignored.")
         return
 
     if isinstance(value, bool):
         value = str(value).lower()
-
-    export_env = "BITOPS_" + export_env
     os.environ[export_env] = str(value)
     logger.info(f"Setting environment variable: [{export_env}], to value: [{value}]")
 

--- a/scripts/plugins/utilities.py
+++ b/scripts/plugins/utilities.py
@@ -178,7 +178,7 @@ def add_value_to_env(export_env, value):
         return
     export_env = "BITOPS_" + export_env
     if os.environ.get(export_env):
-        logger.info("Environment Varible alredy set. Configuration value ignored.")
+        logger.info(f"Environment Varible [{export_env}] already set. BitOps Configuration value ignored.")
         return
 
     if isinstance(value, bool):

--- a/scripts/plugins/utilities.py
+++ b/scripts/plugins/utilities.py
@@ -176,8 +176,7 @@ def add_value_to_env(export_env, value):
     """
     if value is None or value == "" or value == "None" or export_env is None or export_env == "":
         return
-    
-    if os.environ.get('BITOPS_'+export_env):
+    if os.environ.get("BITOPS_" + export_env):
         logger.info("Environment Varible alredy set. Configuration value ignored.")
         return
 
@@ -370,7 +369,6 @@ def run_cmd(command: Union[list, str]) -> subprocess.Popen:
             stderr=subprocess.STDOUT,
             universal_newlines=True,
         ) as process:
-
             for combined_output in process.stdout:
                 # TODO: parse output for secrets
                 # TODO: specify plugin and output tight output (no extra newlines)


### PR DESCRIPTION
Adding environment variable check, if found ignore bitops.config attribute w/warning

Fixes # (issue)
Fixes https://github.com/bitovi/bitops/issues/371

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes and post the logs from the local testing that are relevant. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. 


**Logs**
Isolated into script for testing; 
```
[Bitovi] [bitops] $ export TEST_371=true; python3 test.py
Please enter a value: TEST
Unable to find environment variable: [TEST]
Please enter a value: TEST_371
Environment Varible alredy set. Configuration value ignored.
```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
