### PR TITLE
Switch to "WARNING" logging level by default

### DIFF
--- a/bitops.config.yaml
+++ b/bitops.config.yaml
@@ -7,7 +7,7 @@ bitops:
   run_mode: default   # (Unused for now)
   # LEVELS: [ DEBUG, INFO, WARNING, ERROR, CRITICAL ]
   logging:      
-    level: DEBUG              # Sets the logging level
+    level: WARNING              # Sets the logging level
     color:
       enabled: true           # Enables colored logs
     filename: bitops-run      # log filename

--- a/docs/examples/plugin-examples/plugin-no-install/duplicate-environment/bitops-level/bitops.config.yaml
+++ b/docs/examples/plugin-examples/plugin-no-install/duplicate-environment/bitops-level/bitops.config.yaml
@@ -1,7 +1,7 @@
 bitops:
   fail_fast: true
   logging:      
-    level: DEBUG              # Sets the logging level
+    level: WARNING              # Sets the logging level
     color:
       enabled: true           # Enables colored logs
   plugins:    

--- a/prebuilt-config/aws-ansible/bitops.config.yaml
+++ b/prebuilt-config/aws-ansible/bitops.config.yaml
@@ -7,7 +7,7 @@ bitops:
   run_mode: default   # (Unused for now)
   # LEVELS: [ DEBUG, INFO, WARNING, ERROR, CRITICAL ]
   logging:      
-    level: DEBUG              # Sets the logging level
+    level: WARNING              # Sets the logging level
     color:
       enabled: true           # Enables colored logs
     filename: bitops-run      # log filename

--- a/prebuilt-config/aws-helm/bitops.config.yaml
+++ b/prebuilt-config/aws-helm/bitops.config.yaml
@@ -7,7 +7,7 @@ bitops:
   run_mode: default   # (Unused for now)
   # LEVELS: [ DEBUG, INFO, WARNING, ERROR, CRITICAL ]
   logging:      
-    level: DEBUG              # Sets the logging level
+    level: WARNING              # Sets the logging level
     color:
       enabled: true           # Enables colored logs
     filename: bitops-run      # log filename

--- a/prebuilt-config/aws-terraform/bitops.config.yaml
+++ b/prebuilt-config/aws-terraform/bitops.config.yaml
@@ -7,7 +7,7 @@ bitops:
   run_mode: default   # (Unused for now)
   # LEVELS: [ DEBUG, INFO, WARNING, ERROR, CRITICAL ]
   logging:      
-    level: DEBUG              # Sets the logging level
+    level: WARNING              # Sets the logging level
     color:
       enabled: true           # Enables colored logs
     filename: bitops-run      # log filename

--- a/prebuilt-config/example-plugin/bitops.config.yaml
+++ b/prebuilt-config/example-plugin/bitops.config.yaml
@@ -7,7 +7,7 @@ bitops:
   run_mode: default   # (Unused for now)
   # LEVELS: [ DEBUG, INFO, WARNING, ERROR, CRITICAL ]
   logging:      
-    level: DEBUG              # Sets the logging level
+    level: WARNING              # Sets the logging level
     color:
       enabled: true           # Enables colored logs
     filename: bitops-run      # log filename

--- a/prebuilt-config/omnibus/bitops.config.yaml
+++ b/prebuilt-config/omnibus/bitops.config.yaml
@@ -7,7 +7,7 @@ bitops:
   run_mode: default   # (Unused for now)
   # LEVELS: [ DEBUG, INFO, WARNING, ERROR, CRITICAL ]
   logging:      
-    level: DEBUG              # Sets the logging level
+    level: WARNING              # Sets the logging level
     color:
       enabled: true           # Enables colored logs
     filename: bitops-run      # log filename


### PR DESCRIPTION
Switch the default logging level to `WARNING` instead of `DEBUG` for BitOps.

As we're starting to show the BitOps to others, be mindful of what data we show as logs, - users should be getting only the important messages, excluding all the noise.

Somewhat relevant to https://github.com/bitovi/bitops/issues/270, which highlights a bigger problem with the log formatting standards.
