### PR TITLE
Make BITOPS_ ENV import part of the schema processing

### DIFF
--- a/scripts/plugins/utilities.py
+++ b/scripts/plugins/utilities.py
@@ -104,7 +104,7 @@ class SchemaObject:  # pylint: disable=too-many-instance-attributes
             )
             self.value = os.environ[import_env]
             return
-        elif found_config_value:
+        if found_config_value:
             logger.info(
                 f"Config override found for: [{self.name}], default: [{self.default}], "
                 f"new value: [{found_config_value}]"
@@ -185,7 +185,7 @@ def add_value_to_env(export_env, value):
     """
     if value is None or value == "" or value == "None" or export_env is None or export_env == "":
         return
-    
+
     if isinstance(value, bool):
         value = str(value).lower()
 


### PR DESCRIPTION
This is a follow-up to #371
I tested https://github.com/bitovi/bitops/pull/396 and logic for handling the user's defined `BITOPS_` env vars fixes the issue only partially.

The entire ENV variable import should be part of the BitOps schema processing pipeline.
The important point is that we want to use imported ENV as a `self.value` in `SchemaObject`.
It will help convert the merged bitops config (`ENV > Config > Defaults`) into a generated CLI in the next steps.
