### PR TITLE
Fix ENV export prefix regression in #395

### DIFF
--- a/scripts/plugins/utilities.py
+++ b/scripts/plugins/utilities.py
@@ -198,10 +198,6 @@ def add_value_to_env(export_env, value):
     if isinstance(value, list):
         value = " ".join(value)
 
-    export_env = "BITOPS_" + export_env
-    os.environ[export_env] = str(value)
-    logger.info(f"Setting environment variable: [{export_env}], to value: [{value}]")
-
     os.environ[export_env] = str(value)
     logger.info(f"Setting export environment variable: [{export_env}], to value: [{value}]")
 


### PR DESCRIPTION
Found a bug with var export while testing fresh `bitops:dev`.

Looks like #395 merge conflict added some unneeded code 
https://github.com/bitovi/bitops/pull/395/files#r1110451015

Reverting this part back to #403 state.