### PR TITLE
Update ci.yaml to use cache v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
           cache: 'pip'
 
       - name: Cache Python Dependencies and Env
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cache/pip
@@ -53,7 +53,7 @@ jobs:
           cache: 'pip'
 
       - name: Cache Python Dependencies and Env
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cache/pip
@@ -83,7 +83,7 @@ jobs:
           cache: 'pip'
 
       - name: Cache Python Dependencies and Env
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cache/pip


### PR DESCRIPTION
Update cache action to v3 in order to avoid node v12 warning message